### PR TITLE
Handle Nil values for cbg.Deferred

### DIFF
--- a/testgen/main.go
+++ b/testgen/main.go
@@ -10,6 +10,7 @@ func main() {
 		types.SignedArray{},
 		types.SimpleTypeOne{},
 		types.SimpleTypeTwo{},
+		types.DeferredContainer{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -591,3 +591,105 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) error {
 	}
 	return nil
 }
+
+func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{131}); err != nil {
+		return err
+	}
+
+	// t.Stuff (testing.SimpleTypeOne) (struct)
+	if err := t.Stuff.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Deferred (typegen.Deferred) (struct)
+	if err := t.Deferred.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Value (uint64) (uint64)
+
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Value))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) error {
+	br := cbg.GetPeeker(r)
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Stuff (testing.SimpleTypeOne) (struct)
+
+	{
+
+		pb, err := br.PeekByte()
+		if err != nil {
+			return err
+		}
+		if pb == cbg.CborNull[0] {
+			var nbuf [1]byte
+			if _, err := br.Read(nbuf[:]); err != nil {
+				return err
+			}
+		} else {
+			t.Stuff = new(SimpleTypeOne)
+			if err := t.Stuff.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
+			}
+		}
+
+	}
+	// t.Deferred (typegen.Deferred) (struct)
+
+	{
+
+		pb, err := br.PeekByte()
+		if err != nil {
+			return err
+		}
+		if pb == cbg.CborNull[0] {
+			var nbuf [1]byte
+			if _, err := br.Read(nbuf[:]); err != nil {
+				return err
+			}
+		} else {
+			t.Deferred = new(cbg.Deferred)
+			if err := t.Deferred.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.Deferred pointer: %w", err)
+			}
+		}
+
+	}
+	// t.Value (uint64) (uint64)
+
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Value = uint64(extra)
+
+	}
+	return nil
+}

--- a/testing/types.go
+++ b/testing/types.go
@@ -1,5 +1,9 @@
 package testing
 
+import (
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
 type NaturalNumber uint64
 
 type SignedArray struct {
@@ -32,4 +36,10 @@ type SimpleTypeTree struct {
 	Dog                              string
 	SixtyThreeBitIntegerWithASignBit int64
 	NotPizza                         *uint64
+}
+
+type DeferredContainer struct {
+	Stuff    *SimpleTypeOne
+	Deferred *cbg.Deferred
+	Value    uint64
 }

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -94,6 +95,13 @@ type Deferred struct {
 }
 
 func (d *Deferred) MarshalCBOR(w io.Writer) error {
+	if d == nil {
+		_, err := w.Write(CborNull)
+		return err
+	}
+	if d.Raw == nil {
+		return errors.New("cannot marshal Deferred with nil value for Raw (will not unmarshal)")
+	}
 	_, err := w.Write(d.Raw)
 	return err
 }


### PR DESCRIPTION
# Goals

Handle two unusual cases for a cbg.Deferred value in the Marshalling process

# Implementation

- Case: a *cbg.Deferred value is marshaled when the pointer is nil

Resolution: add a self nil check in the Marshall method for *cbg.Deferred and write a cbor.Null

- Case: a *cbg.Deferred value is not nil but has a Raw field that is nil

Resolution: this shouldn't happen. It means you forgot to serialize the deferred value into Raw. Moreover, currently it produces unpredictable behavior because Marshall will succeed (writing nothing), but then nothing is written to the buffer so if a Deferred is in a struct, the immediate proceeding field will likely have an unpredictable error, as it's data will be read into Raw on Unmarshal. Instead, return error on Marshal for this case.