### PR TITLE
fix: clear struct state on unmarshal

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -979,6 +979,8 @@ func emitCborUnmarshalSliceField(w io.Writer, f Field) error {
 func emitCborUnmarshalStructTuple(w io.Writer, gti *GenTypeInfo) error {
 	err := doTemplate(w, gti, `
 func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) error {
+	*t = {{.Name}}{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 
@@ -1141,6 +1143,8 @@ func emitCborMarshalStructMap(w io.Writer, gti *GenTypeInfo) error {
 func emitCborUnmarshalStructMap(w io.Writer, gti *GenTypeInfo) error {
 	err := doTemplate(w, gti, `
 func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) error {
+	*t = {{.Name}}{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -42,6 +42,8 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 }
 
 func (t *SignedArray) UnmarshalCBOR(r io.Reader) error {
+	*t = SignedArray{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 
@@ -151,6 +153,8 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 }
 
 func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) error {
+	*t = SimpleTypeOne{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 
@@ -376,6 +380,8 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 }
 
 func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) error {
+	*t = SimpleTypeTwo{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 
@@ -696,6 +702,8 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 }
 
 func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) error {
+	*t = DeferredContainer{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -184,6 +184,8 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 }
 
 func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
+	*t = SimpleTypeTree{}
+
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)
 


### PR DESCRIPTION
fixes #21

We could also make sure every field write writes to the field, no matter what. However, this is much safer.