### PR TITLE
Forbid nil unless the field is marked nullable

### DIFF
--- a/testgen/main.go
+++ b/testgen/main.go
@@ -12,6 +12,8 @@ func main() {
 		types.SimpleTypeTwo{},
 		types.DeferredContainer{},
 		types.FixedArrays{},
+		types.NotNull{},
+		types.YesNull{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -171,9 +171,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.NotPizza == nil {
+
 		if _, err := w.Write(cbg.CborNull); err != nil {
 			return err
 		}
+
 	} else {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
 			return err
@@ -226,10 +228,12 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 					return err
 				}
 				if pb == cbg.CborNull[0] {
+
 					var nbuf [1]byte
 					if _, err := br.Read(nbuf[:]); err != nil {
 						return err
 					}
+
 				} else {
 					t.Stuff = new(SimpleTypeTree)
 					if err := t.Stuff.UnmarshalCBOR(br); err != nil {
@@ -248,10 +252,12 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 					return err
 				}
 				if pb == cbg.CborNull[0] {
+
 					var nbuf [1]byte
 					if _, err := br.Read(nbuf[:]); err != nil {
 						return err
 					}
+
 				} else {
 					t.Stufff = new(SimpleTypeTwo)
 					if err := t.Stufff.UnmarshalCBOR(br); err != nil {
@@ -389,10 +395,12 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 					return err
 				}
 				if pb == cbg.CborNull[0] {
+
 					var nbuf [1]byte
 					if _, err := br.Read(nbuf[:]); err != nil {
 						return err
 					}
+
 				} else {
 					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 					if err != nil {

--- a/testing/nullable_test.go
+++ b/testing/nullable_test.go
@@ -1,0 +1,132 @@
+package testing
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNotNullMarshal(t *testing.T) {
+	var not NotNull
+
+	buf := new(bytes.Buffer)
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal("should not have serialized null fields")
+	}
+	buf.Reset()
+
+	not.Always = new(SimpleTypeOne)
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal("should not have serialized null fields")
+	}
+	buf.Reset()
+
+	not.Value = new(uint64)
+	if err := not.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+
+	not.Always = nil
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal("should not have serialized null fields")
+	}
+	buf.Reset()
+
+	not.Map = make(map[string]*NotNull)
+	not.Map["foo"] = nil
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal("should not have serialized null fields")
+	}
+	buf.Reset()
+
+	not.Map["foo"] = &NotNull{Always: new(SimpleTypeOne), Value: new(uint64)}
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+
+	not.Slice = append(not.Slice, nil)
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal("should not have serialized null fields")
+	}
+	buf.Reset()
+
+	not.Slice[0] = &NotNull{Always: new(SimpleTypeOne), Value: new(uint64)}
+	if err := not.MarshalCBOR(buf); err == nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+}
+
+func TestNotNullUnmarshal(t *testing.T) {
+	var (
+		yes YesNull
+		not NotNull
+	)
+
+	buf := new(bytes.Buffer)
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := not.UnmarshalCBOR(buf); err == nil {
+		t.Fatal("shouldn't decode null fields")
+	}
+
+	yes.Value = new(uint64)
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := not.UnmarshalCBOR(buf); err == nil {
+		t.Fatal("shouldn't decode null fields")
+	}
+
+	yes.Always = new(SimpleTypeOne)
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := not.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	yes.Map = make(map[string]*YesNull)
+	yes.Map["foo"] = nil
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := not.UnmarshalCBOR(buf); err == nil {
+		t.Fatal("has null value")
+	}
+
+	yes.Map["foo"] = &YesNull{Always: new(SimpleTypeOne), Value: new(uint64)}
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := not.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	yes.Slice = append(yes.Slice, nil)
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := not.UnmarshalCBOR(buf); err == nil {
+		t.Fatal("has null value")
+	}
+
+	yes.Slice[0] = &YesNull{Always: new(SimpleTypeOne), Value: new(uint64)}
+	buf.Reset()
+	if err := yes.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := not.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/testing/types.go
+++ b/testing/types.go
@@ -22,31 +22,45 @@ type SimpleTypeOne struct {
 }
 
 type SimpleTypeTwo struct {
-	Stuff        *SimpleTypeTwo
+	Stuff        *SimpleTypeTwo `cbg:"nullable"`
 	Others       []uint64
 	SignedOthers []int64
 	Test         [][]byte
 	Dog          string
 	Numbers      []NamedNumber
-	Pizza        *uint64
-	PointyPizza  *NamedNumber
+	Pizza        *uint64      `cbg:"nullable"`
+	PointyPizza  *NamedNumber `cbg:"nullable"`
 	Arrrrrghay   [Thingc]SimpleTypeOne
 }
 
 type SimpleTypeTree struct {
-	Stuff                            *SimpleTypeTree
-	Stufff                           *SimpleTypeTwo
+	Stuff                            *SimpleTypeTree `cbg:"nullable"`
+	Stufff                           *SimpleTypeTwo  `cbg:"nullable"`
 	Others                           []uint64
 	Test                             [][]byte
 	Dog                              string
 	SixtyThreeBitIntegerWithASignBit int64
-	NotPizza                         *uint64
+	NotPizza                         *uint64 `cbg:"nullable"`
 }
 
 type DeferredContainer struct {
-	Stuff    *SimpleTypeOne
-	Deferred *cbg.Deferred
+	Stuff    *SimpleTypeOne `cbg:"nullable"`
+	Deferred *cbg.Deferred  `cbg:"nullable"`
 	Value    uint64
+}
+
+type NotNull struct {
+	Always *SimpleTypeOne
+	Value  *uint64
+	Slice  []*NotNull
+	Map    map[string]*NotNull
+}
+
+type YesNull struct {
+	Always *SimpleTypeOne      `cbg:"nullable"`
+	Value  *uint64             `cbg:"nullable"`
+	Slice  []*YesNull          `cbg:"nullable"`
+	Map    map[string]*YesNull `cbg:"nullable"`
 }
 
 type FixedArrays struct {


### PR DESCRIPTION
This change forbids nil pointers (except zero slices/maps) unless the field is explicitly marked as "nullable".

This is usually what users want and can help avoid unexpected null pointer exceptions.

Unfortunately, this is a _massively_ breaking change and should not be merged until we can update downstream projects.