### PR TITLE
Always allocate scratch space when marshalling into a map.

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1085,9 +1085,8 @@ func emitCborMarshalStructMap(w io.Writer, gti *GenTypeInfo) error {
 	if _, err := w.Write({{ .MapHeaderAsByteString }}); err != nil {
 		return err
 	}
-{{ if .NeedsScratch }}
+
 	scratch := make([]byte, 9)
-{{ end }}
 `)
 	if err != nil {
 		return err

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	if err := cbg.WriteMapEncodersToFile("testing/cbor_map_gen.go", "testing",
 		types.SimpleTypeTree{},
+		types.NeedScratchForMap{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -37,6 +37,10 @@ func TestSimpleTypeTree(t *testing.T) {
 	testTypeRoundtrips(t, reflect.TypeOf(SimpleTypeTree{}))
 }
 
+func TestNeedScratchForMap(t *testing.T) {
+	testTypeRoundtrips(t, reflect.TypeOf(NeedScratchForMap{}))
+}
+
 func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmarshaler) {
 
 	buf := new(bytes.Buffer)

--- a/testing/types.go
+++ b/testing/types.go
@@ -54,3 +54,8 @@ type FixedArrays struct {
 	Uint8  [20]uint8
 	Uint64 [20]uint64
 }
+
+// Do not add fields to this type.
+type NeedScratchForMap struct {
+	Thing bool
+}


### PR DESCRIPTION
We use it for writing the keys.