### PR TITLE
Sort map keys according to RFC7049 & DAG-CBOR strict ordering

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -358,7 +358,7 @@ func emitCborMarshalMapField(w io.Writer, f Field) error {
 	for k := range {{ .Name }} {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	cbg.MapKeySort_RFC7049(keys)
 	for _, k := range keys {
 		v := {{ .Name }}[k]
 

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -23,61 +23,27 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	// t.Stuff (testing.SimpleTypeTree) (struct)
-	if len("Stuff") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"Stuff\" was too long")
+	// t.Dog (string) (string)
+	if len("Dog") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Dog\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, string("Stuff")); err != nil {
-		return err
-	}
-
-	if err := t.Stuff.MarshalCBOR(w); err != nil {
+	if _, err := io.WriteString(w, string("Dog")); err != nil {
 		return err
 	}
 
-	// t.Stufff (testing.SimpleTypeTwo) (struct)
-	if len("Stufff") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"Stufff\" was too long")
+	if len(t.Dog) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, string("Stufff")); err != nil {
+	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
 		return err
-	}
-
-	if err := t.Stufff.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.Others ([]uint64) (slice)
-	if len("Others") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"Others\" was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Others"))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string("Others")); err != nil {
-		return err
-	}
-
-	if len(t.Others) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Others was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
-		return err
-	}
-	for _, v := range t.Others {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
-			return err
-		}
 	}
 
 	// t.Test ([][]uint8) (slice)
@@ -113,49 +79,61 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Dog (string) (string)
-	if len("Dog") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"Dog\" was too long")
+	// t.Stuff (testing.SimpleTypeTree) (struct)
+	if len("Stuff") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Stuff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, string("Dog")); err != nil {
-		return err
-	}
-
-	if len(t.Dog) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Dog was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
+	if _, err := io.WriteString(w, string("Stuff")); err != nil {
 		return err
 	}
 
-	// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
-	if len("SixtyThreeBitIntegerWithASignBit") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"SixtyThreeBitIntegerWithASignBit\" was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string("SixtyThreeBitIntegerWithASignBit")); err != nil {
+	if err := t.Stuff.MarshalCBOR(w); err != nil {
 		return err
 	}
 
-	if t.SixtyThreeBitIntegerWithASignBit >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
+	// t.Others ([]uint64) (slice)
+	if len("Others") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Others\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Others"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Others")); err != nil {
+		return err
+	}
+
+	if len(t.Others) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Others was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+		return err
+	}
+	for _, v := range t.Others {
+		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
-	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
-			return err
-		}
+	}
+
+	// t.Stufff (testing.SimpleTypeTwo) (struct)
+	if len("Stufff") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Stufff\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Stufff")); err != nil {
+		return err
+	}
+
+	if err := t.Stufff.MarshalCBOR(w); err != nil {
+		return err
 	}
 
 	// t.NotPizza (uint64) (uint64)
@@ -180,6 +158,27 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
+	// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
+	if len("SixtyThreeBitIntegerWithASignBit") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SixtyThreeBitIntegerWithASignBit\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SixtyThreeBitIntegerWithASignBit")); err != nil {
+		return err
+	}
+
+	if t.SixtyThreeBitIntegerWithASignBit >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -216,80 +215,17 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		switch name {
-		// t.Stuff (testing.SimpleTypeTree) (struct)
-		case "Stuff":
+		// t.Dog (string) (string)
+		case "Dog":
 
 			{
-
-				b, err := br.ReadByte()
+				sval, err := cbg.ReadStringBuf(br, scratch)
 				if err != nil {
 					return err
 				}
-				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
-						return err
-					}
-					t.Stuff = new(SimpleTypeTree)
-					if err := t.Stuff.UnmarshalCBOR(br); err != nil {
-						return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
-					}
-				}
 
+				t.Dog = string(sval)
 			}
-			// t.Stufff (testing.SimpleTypeTwo) (struct)
-		case "Stufff":
-
-			{
-
-				b, err := br.ReadByte()
-				if err != nil {
-					return err
-				}
-				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
-						return err
-					}
-					t.Stufff = new(SimpleTypeTwo)
-					if err := t.Stufff.UnmarshalCBOR(br); err != nil {
-						return xerrors.Errorf("unmarshaling t.Stufff pointer: %w", err)
-					}
-				}
-
-			}
-			// t.Others ([]uint64) (slice)
-		case "Others":
-
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-			if err != nil {
-				return err
-			}
-
-			if extra > cbg.MaxLength {
-				return fmt.Errorf("t.Others: array too large (%d)", extra)
-			}
-
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
-
-			if extra > 0 {
-				t.Others = make([]uint64, extra)
-			}
-
-			for i := 0; i < int(extra); i++ {
-
-				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
-				if err != nil {
-					return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
-				}
-
-				if maj != cbg.MajUnsignedInt {
-					return xerrors.Errorf("value read for array t.Others was not a uint, instead got %d", maj)
-				}
-
-				t.Others[i] = uint64(val)
-			}
-
 			// t.Test ([][]uint8) (slice)
 		case "Test":
 
@@ -338,16 +274,104 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 				}
 			}
 
-			// t.Dog (string) (string)
-		case "Dog":
+			// t.Stuff (testing.SimpleTypeTree) (struct)
+		case "Stuff":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+
+				b, err := br.ReadByte()
 				if err != nil {
 					return err
 				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Stuff = new(SimpleTypeTree)
+					if err := t.Stuff.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
+					}
+				}
 
-				t.Dog = string(sval)
+			}
+			// t.Others ([]uint64) (slice)
+		case "Others":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Others: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Others = make([]uint64, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
+				}
+
+				if maj != cbg.MajUnsignedInt {
+					return xerrors.Errorf("value read for array t.Others was not a uint, instead got %d", maj)
+				}
+
+				t.Others[i] = uint64(val)
+			}
+
+			// t.Stufff (testing.SimpleTypeTwo) (struct)
+		case "Stufff":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Stufff = new(SimpleTypeTwo)
+					if err := t.Stufff.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Stufff pointer: %w", err)
+					}
+				}
+
+			}
+			// t.NotPizza (uint64) (uint64)
+		case "NotPizza":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					typed := uint64(extra)
+					t.NotPizza = &typed
+				}
+
 			}
 			// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
 		case "SixtyThreeBitIntegerWithASignBit":
@@ -374,31 +398,6 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 				}
 
 				t.SixtyThreeBitIntegerWithASignBit = int64(extraI)
-			}
-			// t.NotPizza (uint64) (uint64)
-		case "NotPizza":
-
-			{
-
-				b, err := br.ReadByte()
-				if err != nil {
-					return err
-				}
-				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
-						return err
-					}
-					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-					if err != nil {
-						return err
-					}
-					if maj != cbg.MajUnsignedInt {
-						return fmt.Errorf("wrong type for uint64 field")
-					}
-					typed := uint64(extra)
-					t.NotPizza = &typed
-				}
-
 			}
 
 		default:

--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"sort"
 	"time"
 
 	cid "github.com/ipfs/go-cid"
@@ -730,4 +731,18 @@ func (ct *CborTime) UnmarshalJSON(b []byte) error {
 	}
 	*(*time.Time)(ct) = t
 	return nil
+}
+
+func MapKeySort_RFC7049(keys []string) {
+	sort.Slice(keys, func(i, j int) bool {
+		return mapKeySort_RFC7049Less(keys[i], keys[j])
+	})
+}
+
+func mapKeySort_RFC7049Less(k1 string, k2 string) bool {
+	li, lj := len(k1), len(k2)
+	if li == lj {
+		return k1 < k2
+	}
+	return li < lj
 }

--- a/writefile.go
+++ b/writefile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"go/format"
 	"os"
+	"sort"
 
 	"golang.org/x/xerrors"
 )
@@ -59,6 +60,9 @@ func WriteMapEncodersToFile(fname, pkg string, types ...interface{}) error {
 		if err != nil {
 			return xerrors.Errorf("failed to parse type info: %w", err)
 		}
+		sort.Slice(gti.Fields, func(i, j int) bool {
+			return mapKeySort_RFC7049Less(gti.Fields[i].Name, gti.Fields[j].Name)
+		})
 		typeInfos[i] = gti
 	}
 


### PR DESCRIPTION
I know this is disruptive where maps are used,  and _very_ late for Filecoin, so obviously proceed with caution.

This adds proper RFC7049 map key sorting, to both bare maps and structs in map representation. The other DAG-CBOR codec implementations strictly sort by length first, then bytes, as per https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#strictness. The current implementation will render CBOR that won't produce stable CIDs with a round-trip using another DAG-CBOR encoder.

Illustrated by a failed round-trip attempt on this:

![genesis_keysort](https://user-images.githubusercontent.com/495647/91122655-2f5d6700-e6de-11ea-8835-fe1e7768d8bd.png)
