### PR TITLE
Protect against stray EOFs

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -611,6 +611,9 @@ func emitCborUnmarshalStructField(w io.Writer, f Field) error {
 	if extra > 0 {
 		buf := make([]byte, extra)
 		if _, err := io.ReadFull(br, buf); err != nil {
+			if err == io.EOF {
+				err = io.ErrUnexpectedEOF
+			}
 			return err
 		}
 		{{ .Name }} = big.NewInt(0).SetBytes(buf)
@@ -898,6 +901,9 @@ func emitCborUnmarshalSliceField(w io.Writer, f Field) error {
 	}
 	{{end}}
 	if _, err := io.ReadFull(br, {{ .Name }}[:]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return err
 	}
 `)

--- a/peeker.go
+++ b/peeker.go
@@ -63,7 +63,15 @@ func (p *peeker) ReadByte() (byte, error) {
 	var buf [1]byte
 	n, err := p.reader.Read(buf[:])
 	if n == 0 {
+		if err == nil {
+			err = io.ErrNoProgress
+		}
 		return 0, err
+	}
+	// ReadByte is not allowed to return an EOF when a byte was successfully
+	// read, but the underlying reader is allowed to do so.
+	if err == io.EOF {
+		err = nil
 	}
 	b := buf[0]
 	p.lastByte = b

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -225,6 +225,9 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) error {
 	}
 
 	if _, err := io.ReadFull(br, t.Binary[:]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return err
 	}
 	// t.Signed (int64) (int64)
@@ -563,6 +566,9 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) error {
 			}
 
 			if _, err := io.ReadFull(br, t.Test[i][:]); err != nil {
+				if err == io.EOF {
+					err = io.ErrUnexpectedEOF
+				}
 				return err
 			}
 		}
@@ -883,6 +889,9 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) error {
 	t.Bytes = [20]uint8{}
 
 	if _, err := io.ReadFull(br, t.Bytes[:]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return err
 	}
 	// t.Uint8 ([20]uint8) (array)
@@ -906,6 +915,9 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) error {
 	t.Uint8 = [20]uint8{}
 
 	if _, err := io.ReadFull(br, t.Uint8[:]); err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return err
 	}
 	// t.Uint64 ([20]uint64) (array)

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -333,6 +333,9 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) error {
 					}
 
 					if _, err := io.ReadFull(br, t.Test[i][:]); err != nil {
+						if err == io.EOF {
+							err = io.ErrUnexpectedEOF
+						}
 						return err
 					}
 				}


### PR DESCRIPTION
Unfortunately:

1. Read can read bytes and return an EOF at the same time (could cause us to fail to parse something that's actually correct).
2. ReadByte is not allowed to do this (fixed in PeekByte).
3. Returning EOF on _actual_ error cases can cause the error to be silently dropped somewhere up the stack (where the EOF may be interpreted as "I'm done"). I've replaced EOF with ErrUnexpectedEOF where appropriate.

This crap really shouldn't be necessary, but such is life.