### PR TITLE
Rename fields when generating map encodings

### DIFF
--- a/testgen/main.go
+++ b/testgen/main.go
@@ -20,6 +20,7 @@ func main() {
 	if err := cbg.WriteMapEncodersToFile("testing/cbor_map_gen.go", "testing",
 		types.SimpleTypeTree{},
 		types.NeedScratchForMap{},
+		types.MapWithRenames{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -43,6 +43,10 @@ func TestNeedScratchForMap(t *testing.T) {
 	testTypeRoundtrips(t, reflect.TypeOf(NeedScratchForMap{}))
 }
 
+func TestMapWithRenames(t *testing.T) {
+	testTypeRoundtrips(t, reflect.TypeOf(MapWithRenames{}))
+}
+
 func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmarshaler) {
 
 	buf := new(bytes.Buffer)

--- a/testing/types.go
+++ b/testing/types.go
@@ -65,3 +65,9 @@ type ThingWithSomeTime struct {
 type NeedScratchForMap struct {
 	Thing bool
 }
+
+type MapWithRenames struct {
+	String string `json:"s"`
+	Int    uint64 `json:"i"`
+	Bytes  []byte `json:"b"`
+}


### PR DESCRIPTION
# Goals

Allow using keys other than the actual field name when generating map encodings.

# Implementation

If a struct field has a tag with key "json", use that as the "name" for the field when generating a map encoder as opposed to the actual field's name. (otherwise just use the name)

This has a number of potential uses:
1. using shorter key names for size concerns
2. being able to rename struct fields without breaking compatibility with old versions.