### PR TITLE
feat: allow unmarshaling of struct with more fields than marshaled struct

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -64,6 +64,7 @@ import (
 
 
 var _ = xerrors.Errorf
+var _ = cid.Undef
 
 `)
 }
@@ -1269,7 +1270,8 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) error {
 
 	return doTemplate(w, gti, `
 		default:
-			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid){})
 		}
 	}
 

--- a/gen.go
+++ b/gen.go
@@ -57,6 +57,7 @@ package {{ .Package }}
 import (
 	"fmt"
 	"io"
+	"sort"
 
 {{ range .Imports }}{{ .Name }} "{{ .PkgPath }}"
 {{ end }}
@@ -65,6 +66,7 @@ import (
 
 var _ = xerrors.Errorf
 var _ = cid.Undef
+var _ = sort.Sort
 
 `)
 }

--- a/package.go
+++ b/package.go
@@ -16,6 +16,7 @@ var (
 	defaultImports = []Import{
 		{Name: "cbg", PkgPath: "github.com/whyrusleeping/cbor-gen"},
 		{Name: "xerrors", PkgPath: "golang.org/x/xerrors"},
+		{Name: "cid", PkgPath: "github.com/ipfs/go-cid"},
 	}
 )
 

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -20,6 +20,8 @@ func main() {
 	if err := cbg.WriteMapEncodersToFile("testing/cbor_map_gen.go", "testing",
 		types.SimpleTypeTree{},
 		types.NeedScratchForMap{},
+		types.SimpleStructV1{},
+		types.SimpleStructV2{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 
+	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )
 
 var _ = xerrors.Errorf
+var _ = cid.Undef
 
 var lengthBufSignedArray = []byte{129}
 

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -5,6 +5,7 @@ package testing
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -13,6 +14,7 @@ import (
 
 var _ = xerrors.Errorf
 var _ = cid.Undef
+var _ = sort.Sort
 
 var lengthBufSignedArray = []byte{129}
 

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -166,11 +166,21 @@ func TestTimeIsh(t *testing.T) {
 
 func TestLessToMoreFieldsRoundTrip(t *testing.T) {
 	dummyCid, _ := cid.Parse("bafkqaaa")
+	simpleTypeOne := SimpleTypeOne{
+		Foo:     "foo",
+		Value:   1,
+		Binary:  []byte("bin"),
+		Signed:  -1,
+		NString: "namedstr",
+	}
 	obj := &SimpleStructV1{
 		OldStr: "hello",
 		OldBytes: []byte("bytes"),
 		OldNum: 10,
 		OldPtr: &dummyCid,
+		OldMap: map[string]SimpleTypeOne{"first": simpleTypeOne},
+		OldArray: []SimpleTypeOne{simpleTypeOne},
+		OldStruct: simpleTypeOne,
 	}
 
 	buf := new(bytes.Buffer)
@@ -213,20 +223,61 @@ func TestLessToMoreFieldsRoundTrip(t *testing.T) {
 	if nobj.NewPtr != nil {
 		t.Fatal("expected field to be zero value")
 	}
+
+	if !cmp.Equal(obj.OldMap, nobj.OldMap) {
+		t.Fatal("mismatch map marshal / unmarshal")
+	}
+	if len(nobj.NewMap) != 0 {
+		t.Fatal("expected field to be zero value")
+	}
+
+	if !cmp.Equal(obj.OldArray, nobj.OldArray) {
+		t.Fatal("mismatch array marshal / unmarshal")
+	}
+	if len(nobj.NewArray) != 0 {
+		t.Fatal("expected field to be zero value")
+	}
+
+	if !cmp.Equal(obj.OldStruct, nobj.OldStruct) {
+		t.Fatal("mismatch struct marshal / unmarshal")
+	}
+	if !cmp.Equal(nobj.NewStruct, SimpleTypeOne{}) {
+		t.Fatal("expected field to be zero value")
+	}
 }
 
 func TestMoreToLessFieldsRoundTrip(t *testing.T) {
 	dummyCid1, _ := cid.Parse("bafkqaaa")
 	dummyCid2, _ := cid.Parse("bafkqaab")
+	simpleType1 := SimpleTypeOne{
+		Foo:     "foo",
+		Value:   1,
+		Binary:  []byte("bin"),
+		Signed:  -1,
+		NString: "namedstr",
+	}
+	simpleType2 := SimpleTypeOne{
+		Foo:     "bar",
+		Value:   2,
+		Binary:  []byte("bin2"),
+		Signed:  -2,
+		NString: "namedstr2",
+	}
 	obj := &SimpleStructV2{
-		OldStr: "oldstr",
-		NewStr: "newstr",
-		OldBytes: []byte("oldbytes"),
-		NewBytes: []byte("newbytes"),
-		OldNum: 10,
-		NewNum: 11,
-		OldPtr: &dummyCid1,
-		NewPtr: &dummyCid2,
+		OldStr:    "oldstr",
+		NewStr:    "newstr",
+		OldBytes:  []byte("oldbytes"),
+		NewBytes:  []byte("newbytes"),
+		OldNum:    10,
+		NewNum:    11,
+		OldPtr:    &dummyCid1,
+		NewPtr:    &dummyCid2,
+		OldMap:    map[string]SimpleTypeOne{"foo": simpleType1},
+		NewMap:    map[string]SimpleTypeOne{"bar": simpleType2},
+		OldArray: []SimpleTypeOne{simpleType1},
+		NewArray: []SimpleTypeOne{simpleType1, simpleType2},
+		OldStruct: simpleType1,
+		NewStruct: simpleType2,
 	}
 
 	buf := new(bytes.Buffer)
@@ -253,5 +304,14 @@ func TestMoreToLessFieldsRoundTrip(t *testing.T) {
 	}
 	if *obj.OldPtr != *nobj.OldPtr {
 		t.Fatal("mismatch ", obj.OldPtr, " != ", nobj.OldPtr)
+	}
+	if !cmp.Equal(obj.OldMap, nobj.OldMap) {
+		t.Fatal("mismatch map marshal / unmarshal")
+	}
+	if !cmp.Equal(obj.OldArray, nobj.OldArray) {
+		t.Fatal("mismatch array marshal / unmarshal")
+	}
+	if !cmp.Equal(obj.OldStruct, nobj.OldStruct) {
+		t.Fatal("mismatch struct marshal / unmarshal")
 	}
 }

--- a/testing/types.go
+++ b/testing/types.go
@@ -49,6 +49,9 @@ type SimpleStructV1 struct {
 	OldBytes []byte
 	OldNum uint64
 	OldPtr *cid.Cid
+	OldMap map[string]SimpleTypeOne
+	OldArray []SimpleTypeOne
+	OldStruct SimpleTypeOne
 }
 
 type SimpleStructV2 struct {
@@ -63,6 +66,15 @@ type SimpleStructV2 struct {
 
 	OldPtr *cid.Cid
 	NewPtr *cid.Cid
+
+	OldMap map[string]SimpleTypeOne
+	NewMap map[string]SimpleTypeOne
+
+	OldArray []SimpleTypeOne
+	NewArray []SimpleTypeOne
+
+	OldStruct SimpleTypeOne
+	NewStruct SimpleTypeOne
 }
 
 type DeferredContainer struct {

--- a/testing/types.go
+++ b/testing/types.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
@@ -41,6 +42,27 @@ type SimpleTypeTree struct {
 	Dog                              string
 	SixtyThreeBitIntegerWithASignBit int64
 	NotPizza                         *uint64
+}
+
+type SimpleStructV1 struct {
+	OldStr string
+	OldBytes []byte
+	OldNum uint64
+	OldPtr *cid.Cid
+}
+
+type SimpleStructV2 struct {
+	OldStr string
+	NewStr string
+
+	OldBytes []byte
+	NewBytes []byte
+
+	OldNum uint64
+	NewNum uint64
+
+	OldPtr *cid.Cid
+	NewPtr *cid.Cid
 }
 
 type DeferredContainer struct {


### PR DESCRIPTION
It's useful to be able to add a field to a struct and for older versions of the code to ignore the added field when unmarshaling.
```
// V1
type Animal struct {
  Legs int
}

...

// V2
type Animal struct {
  Legs int
  Eyes int
}
```

This PR modifies the unmarshaling code such that it will ignore any fields it doesn't recognize.