### PR TITLE
fix: import "math" in generated code for uint8 unmarshalling

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -57,6 +57,7 @@ package {{ .Package }}
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 
 {{ range .Imports }}{{ .Name }} "{{ .PkgPath }}"
@@ -66,6 +67,7 @@ import (
 
 var _ = xerrors.Errorf
 var _ = cid.Undef
+var _ = math.E
 var _ = sort.Sort
 
 `)

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -5,6 +5,7 @@ package testing
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 
 	cid "github.com/ipfs/go-cid"
@@ -14,6 +15,7 @@ import (
 
 var _ = xerrors.Errorf
 var _ = cid.Undef
+var _ = math.E
 var _ = sort.Sort
 
 var lengthBufSignedArray = []byte{129}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -5,6 +5,7 @@ package testing
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 
 	cid "github.com/ipfs/go-cid"
@@ -14,6 +15,7 @@ import (
 
 var _ = xerrors.Errorf
 var _ = cid.Undef
+var _ = math.E
 var _ = sort.Sort
 
 func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {


### PR DESCRIPTION
This fix the following bug:

Currently generated code for unmarshalling `uint8` field:
```go
	// t.Type (service.TimeFilterType) (uint8)

	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
	if err != nil {
		return err
	}
	if maj != cbg.MajUnsignedInt {
		return fmt.Errorf("wrong type for uint8 field")
	}
	if extra > math.MaxUint8 {
		return fmt.Errorf("integer in input was too large for uint8 field")
	}
	t.Type = TimeFilterType(extra)
```

`math` package is used in above code but the import statement for `math` is not generated, so generated code won't compile.

@Stebalien 
