### PR TITLE
feat: take cbor adapters by-value when encoding

### DIFF
--- a/cbor_cid.go
+++ b/cbor_cid.go
@@ -8,8 +8,8 @@ import (
 
 type CborCid cid.Cid
 
-func (c *CborCid) MarshalCBOR(w io.Writer) error {
-	return WriteCid(w, cid.Cid(*c))
+func (c CborCid) MarshalCBOR(w io.Writer) error {
+	return WriteCid(w, cid.Cid(c))
 }
 
 func (c *CborCid) UnmarshalCBOR(r io.Reader) error {

--- a/utils.go
+++ b/utils.go
@@ -626,8 +626,8 @@ func WriteCidBuf(buf []byte, w io.Writer, c cid.Cid) error {
 
 type CborBool bool
 
-func (cb *CborBool) MarshalCBOR(w io.Writer) error {
-	return WriteBool(w, bool(*cb))
+func (cb CborBool) MarshalCBOR(w io.Writer) error {
+	return WriteBool(w, bool(cb))
 }
 
 func (cb *CborBool) UnmarshalCBOR(r io.Reader) error {
@@ -653,8 +653,8 @@ func (cb *CborBool) UnmarshalCBOR(r io.Reader) error {
 
 type CborInt int64
 
-func (ci *CborInt) MarshalCBOR(w io.Writer) error {
-	v := int64(*ci)
+func (ci CborInt) MarshalCBOR(w io.Writer) error {
+	v := int64(ci)
 	if v >= 0 {
 		if err := WriteMajorTypeHeader(w, MajUnsignedInt, uint64(v)); err != nil {
 			return err
@@ -695,7 +695,7 @@ func (ci *CborInt) UnmarshalCBOR(r io.Reader) error {
 
 type CborTime time.Time
 
-func (ct *CborTime) MarshalCBOR(w io.Writer) error {
+func (ct CborTime) MarshalCBOR(w io.Writer) error {
 	nsecs := ct.Time().UnixNano()
 
 	cbi := CborInt(nsecs)


### PR DESCRIPTION
This just makes our lives easier when using them. We can now, e.g., pass `CborInt(1)` to something that expects a `CBORMarshaler`.