### PR TITLE
Fix: add empty struct marshaling

### DIFF
--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -101,7 +101,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSimpleTypeOne = []byte{133}
+var lengthBufSimpleTypeOne = []byte{134}
 
 func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -167,6 +167,12 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 	if _, err := io.WriteString(w, string(t.NString)); err != nil {
 		return err
 	}
+
+	// t.EmptyStruct (struct {}) (struct)
+	if _, err := w.Write(cbg.CborNull); err != nil {
+		return err
+	}
+	_ = t.EmptyStruct
 	return nil
 }
 
@@ -184,7 +190,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 5 {
+	if extra != 6 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -267,6 +273,15 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.NString = NamedString(sval)
+	}
+	// t.EmptyStruct (struct {}) (struct)
+
+	b, err := br.ReadByte()
+	if err != nil {
+		return err
+	}
+	if b != cbg.CborNull[0] {
+		return fmt.Errorf("incorrect empty struct type")
 	}
 	return nil
 }

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -509,7 +509,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{167}); err != nil {
+	if _, err := w.Write([]byte{168}); err != nil {
 		return err
 	}
 
@@ -643,6 +643,54 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			if err := v.MarshalCBOR(w); err != nil {
 				return err
 			}
+
+		}
+	}
+
+	// t.OldEmptyMap (map[string]struct {}) (map)
+	if len("OldEmptyMap") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"OldEmptyMap\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldEmptyMap"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("OldEmptyMap")); err != nil {
+		return err
+	}
+
+	{
+		if len(t.OldEmptyMap) > 4096 {
+			return xerrors.Errorf("cannot marshal t.OldEmptyMap map too large")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldEmptyMap))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(t.OldEmptyMap))
+		for k := range t.OldEmptyMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := t.OldEmptyMap[k]
+
+			if len(k) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(k)); err != nil {
+				return err
+			}
+
+			if _, err := w.Write(cbg.CborNull); err != nil {
+				return err
+			}
+			_ = v
 
 		}
 	}
@@ -836,6 +884,48 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) error {
 				t.OldMap[k] = v
 
 			}
+			// t.OldEmptyMap (map[string]struct {}) (map)
+		case "OldEmptyMap":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajMap {
+				return fmt.Errorf("expected a map (major type 5)")
+			}
+			if extra > 4096 {
+				return fmt.Errorf("t.OldEmptyMap: map too large")
+			}
+
+			t.OldEmptyMap = make(map[string]struct{}, extra)
+
+			for i, l := 0, int(extra); i < l; i++ {
+
+				var k string
+
+				{
+					sval, err := cbg.ReadStringBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+
+					k = string(sval)
+				}
+
+				var v struct{}
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					return fmt.Errorf("incorrect empty struct type")
+				}
+
+				t.OldEmptyMap[k] = v
+
+			}
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
@@ -890,7 +980,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{174}); err != nil {
+	if _, err := w.Write([]byte{176}); err != nil {
 		return err
 	}
 
@@ -1156,6 +1246,102 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			if err := v.MarshalCBOR(w); err != nil {
 				return err
 			}
+
+		}
+	}
+
+	// t.OldEmptyMap (map[string]struct {}) (map)
+	if len("OldEmptyMap") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"OldEmptyMap\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldEmptyMap"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("OldEmptyMap")); err != nil {
+		return err
+	}
+
+	{
+		if len(t.OldEmptyMap) > 4096 {
+			return xerrors.Errorf("cannot marshal t.OldEmptyMap map too large")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldEmptyMap))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(t.OldEmptyMap))
+		for k := range t.OldEmptyMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := t.OldEmptyMap[k]
+
+			if len(k) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(k)); err != nil {
+				return err
+			}
+
+			if _, err := w.Write(cbg.CborNull); err != nil {
+				return err
+			}
+			_ = v
+
+		}
+	}
+
+	// t.NewEmptyMap (map[string]struct {}) (map)
+	if len("NewEmptyMap") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"NewEmptyMap\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewEmptyMap"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("NewEmptyMap")); err != nil {
+		return err
+	}
+
+	{
+		if len(t.NewEmptyMap) > 4096 {
+			return xerrors.Errorf("cannot marshal t.NewEmptyMap map too large")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.NewEmptyMap))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(t.NewEmptyMap))
+		for k := range t.NewEmptyMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := t.NewEmptyMap[k]
+
+			if len(k) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(k)); err != nil {
+				return err
+			}
+
+			if _, err := w.Write(cbg.CborNull); err != nil {
+				return err
+			}
+			_ = v
 
 		}
 	}
@@ -1501,6 +1687,90 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) error {
 				}
 
 				t.NewMap[k] = v
+
+			}
+			// t.OldEmptyMap (map[string]struct {}) (map)
+		case "OldEmptyMap":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajMap {
+				return fmt.Errorf("expected a map (major type 5)")
+			}
+			if extra > 4096 {
+				return fmt.Errorf("t.OldEmptyMap: map too large")
+			}
+
+			t.OldEmptyMap = make(map[string]struct{}, extra)
+
+			for i, l := 0, int(extra); i < l; i++ {
+
+				var k string
+
+				{
+					sval, err := cbg.ReadStringBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+
+					k = string(sval)
+				}
+
+				var v struct{}
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					return fmt.Errorf("incorrect empty struct type")
+				}
+
+				t.OldEmptyMap[k] = v
+
+			}
+			// t.NewEmptyMap (map[string]struct {}) (map)
+		case "NewEmptyMap":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajMap {
+				return fmt.Errorf("expected a map (major type 5)")
+			}
+			if extra > 4096 {
+				return fmt.Errorf("t.NewEmptyMap: map too large")
+			}
+
+			t.NewEmptyMap = make(map[string]struct{}, extra)
+
+			for i, l := 0, int(extra); i < l; i++ {
+
+				var k string
+
+				{
+					sval, err := cbg.ReadStringBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+
+					k = string(sval)
+				}
+
+				var v struct{}
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					return fmt.Errorf("incorrect empty struct type")
+				}
+
+				t.NewEmptyMap[k] = v
 
 			}
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -167,20 +167,22 @@ func TestTimeIsh(t *testing.T) {
 func TestLessToMoreFieldsRoundTrip(t *testing.T) {
 	dummyCid, _ := cid.Parse("bafkqaaa")
 	simpleTypeOne := SimpleTypeOne{
-		Foo:     "foo",
-		Value:   1,
-		Binary:  []byte("bin"),
-		Signed:  -1,
-		NString: "namedstr",
+		Foo:         "foo",
+		Value:       1,
+		Binary:      []byte("bin"),
+		Signed:      -1,
+		NString:     "namedstr",
+		EmptyStruct: struct{}{},
 	}
 	obj := &SimpleStructV1{
-		OldStr: "hello",
-		OldBytes: []byte("bytes"),
-		OldNum: 10,
-		OldPtr: &dummyCid,
-		OldMap: map[string]SimpleTypeOne{"first": simpleTypeOne},
-		OldArray: []SimpleTypeOne{simpleTypeOne},
-		OldStruct: simpleTypeOne,
+		OldStr:      "hello",
+		OldBytes:    []byte("bytes"),
+		OldNum:      10,
+		OldPtr:      &dummyCid,
+		OldMap:      map[string]SimpleTypeOne{"first": simpleTypeOne},
+		OldEmptyMap: map[string]struct{}{"one": {}},
+		OldArray:    []SimpleTypeOne{simpleTypeOne},
+		OldStruct:   simpleTypeOne,
 	}
 
 	buf := new(bytes.Buffer)
@@ -230,6 +232,12 @@ func TestLessToMoreFieldsRoundTrip(t *testing.T) {
 	if len(nobj.NewMap) != 0 {
 		t.Fatal("expected field to be zero value")
 	}
+	if !cmp.Equal(obj.OldEmptyMap, nobj.OldEmptyMap) {
+		t.Fatal("mismatch map marshal / unmarshal")
+	}
+	if len(nobj.NewEmptyMap) != 0 {
+		t.Fatal("expected field to be zero value")
+	}
 
 	if !cmp.Equal(obj.OldArray, nobj.OldArray) {
 		t.Fatal("mismatch array marshal / unmarshal")
@@ -250,34 +258,38 @@ func TestMoreToLessFieldsRoundTrip(t *testing.T) {
 	dummyCid1, _ := cid.Parse("bafkqaaa")
 	dummyCid2, _ := cid.Parse("bafkqaab")
 	simpleType1 := SimpleTypeOne{
-		Foo:     "foo",
-		Value:   1,
-		Binary:  []byte("bin"),
-		Signed:  -1,
-		NString: "namedstr",
+		Foo:         "foo",
+		Value:       1,
+		Binary:      []byte("bin"),
+		Signed:      -1,
+		NString:     "namedstr",
+		EmptyStruct: struct{}{},
 	}
 	simpleType2 := SimpleTypeOne{
-		Foo:     "bar",
-		Value:   2,
-		Binary:  []byte("bin2"),
-		Signed:  -2,
-		NString: "namedstr2",
+		Foo:         "bar",
+		Value:       2,
+		Binary:      []byte("bin2"),
+		Signed:      -2,
+		NString:     "namedstr2",
+		EmptyStruct: struct{}{},
 	}
 	obj := &SimpleStructV2{
-		OldStr:    "oldstr",
-		NewStr:    "newstr",
-		OldBytes:  []byte("oldbytes"),
-		NewBytes:  []byte("newbytes"),
-		OldNum:    10,
-		NewNum:    11,
-		OldPtr:    &dummyCid1,
-		NewPtr:    &dummyCid2,
-		OldMap:    map[string]SimpleTypeOne{"foo": simpleType1},
-		NewMap:    map[string]SimpleTypeOne{"bar": simpleType2},
-		OldArray: []SimpleTypeOne{simpleType1},
-		NewArray: []SimpleTypeOne{simpleType1, simpleType2},
-		OldStruct: simpleType1,
-		NewStruct: simpleType2,
+		OldStr:      "oldstr",
+		NewStr:      "newstr",
+		OldBytes:    []byte("oldbytes"),
+		NewBytes:    []byte("newbytes"),
+		OldNum:      10,
+		NewNum:      11,
+		OldPtr:      &dummyCid1,
+		NewPtr:      &dummyCid2,
+		OldMap:      map[string]SimpleTypeOne{"foo": simpleType1},
+		NewMap:      map[string]SimpleTypeOne{"bar": simpleType2},
+		OldEmptyMap: map[string]struct{}{"one": {}},
+		NewEmptyMap: map[string]struct{}{"two": {}},
+		OldArray:    []SimpleTypeOne{simpleType1},
+		NewArray:    []SimpleTypeOne{simpleType1, simpleType2},
+		OldStruct:   simpleType1,
+		NewStruct:   simpleType2,
 	}
 
 	buf := new(bytes.Buffer)
@@ -306,6 +318,9 @@ func TestMoreToLessFieldsRoundTrip(t *testing.T) {
 		t.Fatal("mismatch ", obj.OldPtr, " != ", nobj.OldPtr)
 	}
 	if !cmp.Equal(obj.OldMap, nobj.OldMap) {
+		t.Fatal("mismatch map marshal / unmarshal")
+	}
+	if !cmp.Equal(obj.OldEmptyMap, nobj.OldEmptyMap) {
 		t.Fatal("mismatch map marshal / unmarshal")
 	}
 	if !cmp.Equal(obj.OldArray, nobj.OldArray) {

--- a/testing/types.go
+++ b/testing/types.go
@@ -15,11 +15,12 @@ type SignedArray struct {
 }
 
 type SimpleTypeOne struct {
-	Foo     string
-	Value   uint64
-	Binary  []byte
-	Signed  int64
-	NString NamedString
+	Foo         string
+	Value       uint64
+	Binary      []byte
+	Signed      int64
+	NString     NamedString
+	EmptyStruct struct{}
 }
 
 type SimpleTypeTwo struct {
@@ -45,13 +46,14 @@ type SimpleTypeTree struct {
 }
 
 type SimpleStructV1 struct {
-	OldStr string
-	OldBytes []byte
-	OldNum uint64
-	OldPtr *cid.Cid
-	OldMap map[string]SimpleTypeOne
-	OldArray []SimpleTypeOne
-	OldStruct SimpleTypeOne
+	OldStr      string
+	OldBytes    []byte
+	OldNum      uint64
+	OldPtr      *cid.Cid
+	OldMap      map[string]SimpleTypeOne
+	OldEmptyMap map[string]struct{}
+	OldArray    []SimpleTypeOne
+	OldStruct   SimpleTypeOne
 }
 
 type SimpleStructV2 struct {
@@ -69,6 +71,9 @@ type SimpleStructV2 struct {
 
 	OldMap map[string]SimpleTypeOne
 	NewMap map[string]SimpleTypeOne
+
+	OldEmptyMap map[string]struct{}
+	NewEmptyMap map[string]struct{}
 
 	OldArray []SimpleTypeOne
 	NewArray []SimpleTypeOne


### PR DESCRIPTION
I needed to encode a `map[string]struct{}` but ran into this error :

`testing/cbor_gen.go:172:25: t.EmptyStruct.MarshalCBOR undefined (type struct {} has no field or method MarshalCBOR)` which is logical since we can't attach a function to an empty struct : 
```go

EmptyStruct struct{}
...
if err := EmptyStruct.UnmarshalCBOR(br); err != nil {.      // it fails here
     return xerrors.Errorf("unmarshaling t.EmptyStruct: %w", err)
}
````

So I made this fix to handle this case and added some tests