### PR TITLE
Fix read bug in readByteBuf

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -284,14 +284,12 @@ func readByteBuf(r io.Reader, scratch []byte) (byte, error) {
 		return r.ReadByte()
 	case *bufio.Reader:
 		return r.ReadByte()
+	case *peeker:
+		return r.ReadByte()
+	case io.ByteReader:
+		return r.ReadByte()
 	}
-	n, err := r.Read(scratch[:1])
-	if err != nil {
-		return 0, err
-	}
-	if n != 1 {
-		return 0, fmt.Errorf("failed to read a byte")
-	}
+	_, err := io.ReadFull(r, scratch[:1])
 	return scratch[0], err
 }
 

--- a/utils.go
+++ b/utils.go
@@ -24,22 +24,33 @@ func discard(br io.Reader, n int) error {
 	switch r := br.(type) {
 	case *bytes.Buffer:
 		buf := r.Next(n)
-		if len(buf) < n {
+		if len(buf) == 0 {
+			return io.EOF
+		} else if len(buf) < n {
 			return io.ErrUnexpectedEOF
 		}
 		return nil
 	case *bytes.Reader:
-		if r.Len() < n {
+		if r.Len() == 0 {
+			return io.EOF
+		} else if r.Len() < n {
 			_, _ = r.Seek(0, io.SeekEnd)
 			return io.ErrUnexpectedEOF
 		}
 		_, err := r.Seek(int64(n), io.SeekCurrent)
 		return err
 	case *bufio.Reader:
-		_, err := r.Discard(n)
+		discarded, err := r.Discard(n)
+		if discarded != 0 && discarded < n && err == io.EOF {
+			return io.ErrUnexpectedEOF
+		}
 		return err
 	default:
-		_, err := io.CopyN(ioutil.Discard, br, int64(n))
+		discarded, err := io.CopyN(ioutil.Discard, br, int64(n))
+		if discarded != 0 && discarded < int64(n) && err == io.EOF {
+			return io.ErrUnexpectedEOF
+		}
+
 		return err
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,11 @@
 package typegen
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/hex"
+	"fmt"
+	"io"
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
@@ -35,4 +38,116 @@ func TestDeferredMaxLengthSingle(t *testing.T) {
 	if err != maxLengthError {
 		t.Fatal("deferred: allowed more than the maximum allocation supported")
 	}
+}
+
+// TestReadEOFSemantics checks that our helper functions follow this rule when
+// dealing with EOF:
+// If the reader can't read a single byte, it should return err == io.EOF.
+// If the reader could read _some_ of the bytes but not all because of EOF, it
+// should return err == io.ErrUnexpectedEOF.
+// Take a look at the io.EOF doc for  more info: https://pkg.go.dev/io#EOF
+func TestReadEOFSemantics(t *testing.T) {
+	type testCase struct {
+		name       string
+		reader     io.Reader
+		shouldFail bool
+	}
+	newTestCases := func() []testCase {
+		return []testCase{
+			{name: "Reader that returns EOF and n bytes read", reader: &testReader1Byte{b: 0x01}, shouldFail: false},
+			{name: "Exhausted reader", reader: &testReader1Byte{b: 0x01, emptied: true}, shouldFail: true},
+			{name: "Byte buffer", reader: bytes.NewBuffer([]byte{0x01}), shouldFail: false},
+			{name: "Empty Byte buffer", reader: bytes.NewBuffer([]byte{}), shouldFail: true},
+			{name: "Byte Reader", reader: bytes.NewReader([]byte{0x01}), shouldFail: false},
+			{name: "Empty Byte Reader", reader: bytes.NewReader([]byte{}), shouldFail: true},
+			{name: "bufio Reader", reader: bufio.NewReader(bytes.NewReader([]byte{0x01})), shouldFail: false},
+			{name: "bufio Reader with testReader", reader: bufio.NewReader(&testReader1Byte{b: 0x01}), shouldFail: false},
+			{name: "bufio Reader with exhausted testReader", reader: bufio.NewReader(&testReader1Byte{b: 0x01, emptied: true}), shouldFail: true},
+		}
+	}
+
+	utilFns := []func(io.Reader) (byte, error){
+		func(r io.Reader) (byte, error) {
+			return readByte(r)
+		},
+		func(r io.Reader) (byte, error) {
+			return readByteBuf(r, []byte{0x00})
+		},
+		func(r io.Reader) (byte, error) {
+			err := discard(r, 1)
+			return 0x01, err
+		},
+	}
+
+	for i, f := range utilFns {
+		for _, tc := range newTestCases() {
+			t.Run(fmt.Sprintf("util fn #%d against %s", i, tc.name), func(t *testing.T) {
+				b, err := f(tc.reader)
+				if tc.shouldFail && err == nil {
+					t.Fatalf("Expected error. Got nil")
+				} else if !tc.shouldFail && err != nil {
+					t.Fatalf("Expected no error. Got %v", err)
+				} else if tc.shouldFail && err != io.EOF {
+					t.Fatalf("Expected io.EOF. Got %v", err)
+				}
+
+				// readByteBuf should return a nil error with the byte read.
+				if err == nil {
+					if b != 0x01 {
+						t.Fatalf("Expected byte 0x01. Got %x", b)
+					}
+				}
+			})
+		}
+	}
+
+}
+
+// Test that the `discard` helper returns ErrUnexpectedEOF when it discarded
+// some bytes not all and an EOF was encountered along the way.
+func TestDiscardReturnsErrUnexpectedEOF(t *testing.T) {
+	type testCase struct {
+		name   string
+		reader io.Reader
+	}
+	newTestCases := func() []testCase {
+		return []testCase{
+			{name: "Reader that returns EOF and n bytes read", reader: &testReader1Byte{b: 0x01}},
+			{name: "Byte buffer", reader: bytes.NewBuffer([]byte{0x01})},
+			{name: "Byte Reader", reader: bytes.NewReader([]byte{0x01})},
+			{name: "bufio Reader", reader: bufio.NewReader(bytes.NewReader([]byte{0x01}))},
+			{name: "bufio Reader with testReader", reader: bufio.NewReader(&testReader1Byte{b: 0x01})},
+		}
+	}
+
+	// Check that discard returns ErrUnexpectedEOF when it reads 1 but not all the bytes
+	for _, tc := range newTestCases() {
+		t.Run(fmt.Sprintf("discard many bytes against %s", tc.name), func(t *testing.T) {
+			err := discard(tc.reader, 2)
+			if err == nil {
+				// All of these test cases will fail since we are discarding many bytes.
+				t.Fatalf("Expected error. Got nil")
+			} else if err != io.ErrUnexpectedEOF {
+				t.Fatalf("Expected io.ErrUnexpectedEOF. Got %v", err)
+			}
+		})
+	}
+}
+
+type testReader1Byte struct {
+	emptied bool
+	b       byte
+}
+
+func (tr *testReader1Byte) Read(p []byte) (n int, err error) {
+	if tr.emptied {
+		return 0, io.EOF
+	}
+
+	written, err := bytes.NewReader([]byte{tr.b}).Read(p)
+	if written != 1 {
+		panic("unreachable. testReader1Byte has a single byte" + err.Error())
+	}
+	tr.emptied = true
+	return 1, io.EOF
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -42,7 +42,7 @@ func TestDeferredMaxLengthSingle(t *testing.T) {
 
 // TestReadEOFSemantics checks that our helper functions follow this rule when
 // dealing with EOF:
-// If the reader can't read a single byte, it should return err == io.EOF.
+// If the reader can't read a single byte because of EOF, it should return err == io.EOF.
 // If the reader could read _some_ of the bytes but not all because of EOF, it
 // should return err == io.ErrUnexpectedEOF.
 // Take a look at the io.EOF doc for  more info: https://pkg.go.dev/io#EOF


### PR DESCRIPTION
readByteBuf was incorrectly returning the error (EOF) before returning the first byte read. It is a valid for an io.Reader to return both n == 1 and err == EOF (see https://pkg.go.dev/io#Reader). But readByteBuf dropped the read byte and instead returned EOF.

This uses io.ReadFull to handle this logic, where io.ReadFull follows these semantics:
> ReadFull reads exactly len(buf) bytes from r into buf. It returns the number of bytes copied and an error if fewer bytes were read. The error is EOF only if no bytes were read. If an EOF happens after reading some but not all the bytes, ReadFull returns ErrUnexpectedEOF. On return, n == len(buf) if and only if err == nil. If r returns an error having read at least len(buf) bytes, the error is dropped.

This also makes sure that the `discard` helper also follows those semantics. Returning EOF if no bytes were discarded and ErrUnexpectedEOF if only some of the bytes were discarded.

---

Note this started as a continuation of https://github.com/whyrusleeping/cbor-gen/pull/44, but we realized along the way that most of this code was correct by the semantics above.

This change fixes two things:
1. readyByteBuf bug
2. discard not consistently returning io.EOF or io.ErrUnexpectedEOF