### PR TITLE
Make peeker.ReadByte follow buffer.ReadByte semantics

### DIFF
--- a/peeker.go
+++ b/peeker.go
@@ -61,14 +61,14 @@ func (p *peeker) ReadByte() (byte, error) {
 		return p.lastByte, nil
 	}
 	var buf [1]byte
-	n, err := p.reader.Read(buf[:])
-	if n == 0 {
+	_, err := io.ReadFull(p.reader, buf[:])
+	if err != nil {
 		return 0, err
 	}
 	b := buf[0]
 	p.lastByte = b
 	p.peekState = peekSet
-	return b, err
+	return b, nil
 }
 
 func (p *peeker) UnreadByte() error {

--- a/utils_test.go
+++ b/utils_test.go
@@ -55,6 +55,8 @@ func TestReadEOFSemantics(t *testing.T) {
 	newTestCases := func() []testCase {
 		return []testCase{
 			{name: "Reader that returns EOF and n bytes read", reader: &testReader1Byte{b: 0x01}, shouldFail: false},
+			{name: "Peeker with Reader that returns EOF and n bytes read", reader: GetPeeker(&testReader1Byte{b: 0x01}), shouldFail: false},
+			{name: "Peeker with Exhausted Reader", reader: GetPeeker(&testReader1Byte{b: 0x01, emptied: true}), shouldFail: true},
 			{name: "Exhausted reader", reader: &testReader1Byte{b: 0x01, emptied: true}, shouldFail: true},
 			{name: "Byte buffer", reader: bytes.NewBuffer([]byte{0x01}), shouldFail: false},
 			{name: "Empty Byte buffer", reader: bytes.NewBuffer([]byte{}), shouldFail: true},


### PR DESCRIPTION
A continuation of #60. There was an edge case that wasn't checked. If the reader was a peeker it would simply call peeker.ReadByte, which didn't follow the semantics of buffer.ReadByte, readByteBuf, or any other ReadByte method in the Go library. Specifically it should only return an error if it failed to read a byte.

I added a test and also tested this branch against my end code to verify it actually fixes the issue.

@Stebalien since they already have context from #60.