### PR TITLE
Replace scratch buffers with pools

### DIFF
--- a/testing/bench_test.go
+++ b/testing/bench_test.go
@@ -58,7 +58,6 @@ func BenchmarkUnmarshaling(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkLinkScan(b *testing.B) {
@@ -113,6 +112,53 @@ func BenchmarkDeferred(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		reader.Seek(0, io.SeekStart)
 		if err := deferred.UnmarshalCBOR(reader); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapMarshaling(b *testing.B) {
+	r := rand.New(rand.NewSource(56887))
+	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
+	if !ok {
+		b.Fatal("failed to construct type")
+	}
+
+	tt := val.Interface().(SimpleTypeTree)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := tt.MarshalCBOR(ioutil.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapUnmarshaling(b *testing.B) {
+	r := rand.New(rand.NewSource(123456))
+	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
+	if !ok {
+		b.Fatal("failed to construct type")
+	}
+
+	tt := val.Interface().(SimpleTypeTree)
+
+	buf := new(bytes.Buffer)
+	if err := tt.MarshalCBOR(buf); err != nil {
+		b.Fatal(err)
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		reader.Seek(0, io.SeekStart)
+		var tt SimpleTypeTree
+		if err := tt.UnmarshalCBOR(reader); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -29,14 +29,12 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Signed ([]uint64) (slice)
 	if len(t.Signed) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Signed was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Signed))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Signed))); err != nil {
 		return err
 	}
 	for _, v := range t.Signed {
@@ -51,9 +49,8 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SignedArray{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -73,7 +70,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Signed ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -92,7 +89,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Signed slice: %w", err)
 		}
@@ -118,14 +115,12 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Foo (string) (string)
 	if len(t.Foo) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Foo was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Foo))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Foo))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Foo)); err != nil {
@@ -134,7 +129,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -143,7 +138,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Binary was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Binary))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Binary))); err != nil {
 		return err
 	}
 
@@ -153,11 +148,11 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 
 	// t.Signed (int64) (int64)
 	if t.Signed >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
 			return err
 		}
 	}
@@ -167,7 +162,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NString was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.NString))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NString))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NString)); err != nil {
@@ -180,9 +175,8 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeOne{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -203,7 +197,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Foo (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -214,7 +208,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err = cbg.CborReadHeader(br)
 		if err != nil {
 			return err
 		}
@@ -226,7 +220,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Binary ([]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -247,7 +241,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Signed (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
 		if err != nil {
 			return err
@@ -273,7 +267,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.NString (testing.NamedString) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -294,8 +288,6 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeTwo) (struct)
 	if err := t.Stuff.MarshalCBOR(w); err != nil {
 		return err
@@ -306,7 +298,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
@@ -320,16 +312,16 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.SignedOthers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
 		return err
 	}
 	for _, v := range t.SignedOthers {
 		if v >= 0 {
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
 				return err
 			}
 		} else {
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-v-1)); err != nil {
 				return err
 			}
 		}
@@ -340,7 +332,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -348,7 +340,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
@@ -362,7 +354,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -374,7 +366,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Numbers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Numbers))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Numbers))); err != nil {
 		return err
 	}
 	for _, v := range t.Numbers {
@@ -390,7 +382,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
 			return err
 		}
 	}
@@ -402,7 +394,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
 			return err
 		}
 	}
@@ -412,7 +404,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Arrrrrghay was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
 		return err
 	}
 	for _, v := range t.Arrrrrghay {
@@ -427,9 +419,8 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTwo{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -468,7 +459,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Others ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -487,7 +478,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 		}
@@ -501,7 +492,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.SignedOthers ([]int64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -520,7 +511,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 		{
-			maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err := cbg.CborReadHeader(br)
 			var extraI int64
 			if err != nil {
 				return err
@@ -547,7 +538,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Test ([][]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -570,7 +561,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			var extra uint64
 			var err error
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -595,7 +586,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Dog (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -604,7 +595,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Numbers ([]testing.NamedNumber) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -623,7 +614,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Numbers slice: %w", err)
 		}
@@ -647,7 +638,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := br.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -671,7 +662,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := br.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -685,7 +676,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Arrrrrghay ([3]testing.SimpleTypeOne) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -728,8 +719,6 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeOne) (struct)
 	if err := t.Stuff.MarshalCBOR(w); err != nil {
 		return err
@@ -742,7 +731,7 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -753,9 +742,8 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = DeferredContainer{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -806,7 +794,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err = cbg.CborReadHeader(br)
 		if err != nil {
 			return err
 		}
@@ -830,14 +818,12 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Bytes ([20]uint8) (array)
 	if len(t.Bytes) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Bytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
 		return err
 	}
 
@@ -850,7 +836,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Uint8 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
 		return err
 	}
 
@@ -863,7 +849,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Uint64 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Uint64))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Uint64))); err != nil {
 		return err
 	}
 	for _, v := range t.Uint64 {
@@ -878,9 +864,8 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = FixedArrays{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -900,7 +885,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Bytes ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -923,7 +908,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Uint8 ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -946,7 +931,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Uint64 ([20]uint64) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -967,7 +952,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Uint64 slice: %w", err)
 		}
@@ -993,8 +978,6 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.When (typegen.CborTime) (struct)
 	if err := t.When.MarshalCBOR(w); err != nil {
 		return err
@@ -1002,11 +985,11 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 
 	// t.Stuff (int64) (int64)
 	if t.Stuff >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
 			return err
 		}
 	}
@@ -1016,7 +999,7 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.CatName was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.CatName))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.CatName))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.CatName)); err != nil {
@@ -1029,9 +1012,8 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = ThingWithSomeTime{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1060,7 +1042,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Stuff (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
 		if err != nil {
 			return err
@@ -1086,7 +1068,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.CatName (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -27,14 +27,12 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeTree) (struct)
 	if len("Stuff") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"Stuff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stuff")); err != nil {
@@ -50,7 +48,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Stufff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stufff")); err != nil {
@@ -66,7 +64,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Others\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Others"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Others"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Others")); err != nil {
@@ -77,7 +75,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
@@ -91,7 +89,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Test\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Test"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Test"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Test")); err != nil {
@@ -102,7 +100,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -110,7 +108,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
@@ -124,7 +122,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Dog\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Dog")); err != nil {
@@ -135,7 +133,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -147,7 +145,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"SixtyThreeBitIntegerWithASignBit\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("SixtyThreeBitIntegerWithASignBit")); err != nil {
@@ -155,11 +153,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.SixtyThreeBitIntegerWithASignBit >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
 			return err
 		}
 	}
@@ -169,7 +167,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NotPizza\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NotPizza")); err != nil {
@@ -181,7 +179,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
 			return err
 		}
 	}
@@ -193,9 +191,8 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTree{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -219,7 +216,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -271,7 +268,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Others ([]uint64) (slice)
 		case "Others":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -290,7 +287,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			for i := 0; i < int(extra); i++ {
 
-				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, val, err := cbg.CborReadHeader(br)
 				if err != nil {
 					return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 				}
@@ -305,7 +302,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Test ([][]uint8) (slice)
 		case "Test":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -328,7 +325,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					var extra uint64
 					var err error
 
-					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					maj, extra, err = cbg.CborReadHeader(br)
 					if err != nil {
 						return err
 					}
@@ -354,7 +351,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 		case "Dog":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -364,7 +361,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
 		case "SixtyThreeBitIntegerWithASignBit":
 			{
-				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err := cbg.CborReadHeader(br)
 				var extraI int64
 				if err != nil {
 					return err
@@ -400,7 +397,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					if err := br.UnreadByte(); err != nil {
 						return err
 					}
-					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					maj, extra, err = cbg.CborReadHeader(br)
 					if err != nil {
 						return err
 					}
@@ -430,14 +427,12 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Thing (bool) (bool)
 	if len("Thing") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"Thing\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Thing"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Thing"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Thing")); err != nil {
@@ -454,9 +449,8 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = NeedScratchForMap{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -480,7 +474,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -492,7 +486,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Thing (bool) (bool)
 		case "Thing":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -525,14 +519,12 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.OldStr (string) (string)
 	if len("OldStr") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -543,7 +535,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -555,7 +547,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -566,7 +558,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
@@ -579,14 +571,14 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -595,7 +587,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -607,7 +599,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -617,7 +609,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -629,7 +621,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -645,7 +637,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -664,7 +656,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -675,7 +667,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
@@ -689,7 +681,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
@@ -706,9 +698,8 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV1{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -732,7 +723,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -745,7 +736,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -755,7 +746,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -779,7 +770,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -815,7 +806,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -833,7 +824,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -857,7 +848,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -912,14 +903,12 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.OldStr (string) (string)
 	if len("OldStr") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -930,7 +919,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -942,7 +931,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStr")); err != nil {
@@ -953,7 +942,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NewStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NewStr)); err != nil {
@@ -965,7 +954,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -976,7 +965,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
@@ -989,7 +978,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewBytes")); err != nil {
@@ -1000,7 +989,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.NewBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
 		return err
 	}
 
@@ -1013,14 +1002,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -1029,14 +1018,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
 		return err
 	}
 
@@ -1045,7 +1034,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -1057,7 +1046,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -1067,7 +1056,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewPtr")); err != nil {
@@ -1079,7 +1068,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.NewPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.NewPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.NewPtr: %w", err)
 		}
 	}
@@ -1089,7 +1078,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -1101,7 +1090,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -1117,7 +1106,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -1136,7 +1125,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewMap")); err != nil {
@@ -1148,7 +1137,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.NewMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.NewMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.NewMap))); err != nil {
 			return err
 		}
 
@@ -1164,7 +1153,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -1183,7 +1172,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -1194,7 +1183,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
@@ -1208,7 +1197,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewArray")); err != nil {
@@ -1219,7 +1208,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.NewArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.NewArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.NewArray))); err != nil {
 		return err
 	}
 	for _, v := range t.NewArray {
@@ -1233,7 +1222,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
@@ -1249,7 +1238,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStruct")); err != nil {
@@ -1266,9 +1255,8 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV2{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1292,7 +1280,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -1305,7 +1293,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -1316,7 +1304,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "NewStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -1326,7 +1314,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1348,7 +1336,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewBytes ([]uint8) (slice)
 		case "NewBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1372,7 +1360,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -1387,7 +1375,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -1446,7 +1434,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1464,7 +1452,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -1488,7 +1476,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewMap (map[string]testing.SimpleTypeOne) (map)
 		case "NewMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1506,7 +1494,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -1530,7 +1518,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1560,7 +1548,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewArray ([]testing.SimpleTypeOne) (slice)
 		case "NewArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1625,14 +1613,12 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Foo (int64) (int64)
 	if len("foo") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"foo\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("foo"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("foo"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("foo")); err != nil {
@@ -1640,11 +1626,11 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.Foo >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
 			return err
 		}
 	}
@@ -1654,7 +1640,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"beep\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("beep"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("beep"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("beep")); err != nil {
@@ -1665,7 +1651,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Bar was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Bar))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Bar))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Bar)); err != nil {
@@ -1678,9 +1664,8 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = RenamedFields{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1704,7 +1689,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -1716,7 +1701,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Foo (int64) (int64)
 		case "foo":
 			{
-				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err := cbg.CborReadHeader(br)
 				var extraI int64
 				if err != nil {
 					return err
@@ -1743,7 +1728,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		case "beep":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}

--- a/validate.go
+++ b/validate.go
@@ -13,11 +13,8 @@ func ValidateCBOR(b []byte) error {
 
 	br := bytes.NewReader(b)
 
-	// Allocate some scratch space.
-	scratch := make([]byte, maxHeaderSize)
-
 	for remaining := uint64(1); remaining > 0; remaining-- {
-		maj, extra, err := CborReadHeaderBuf(br, scratch)
+		maj, extra, err := CborReadHeader(br)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds pools for small buffers used for reading cbor headers and for larger
buffers used when reading strings. This trades off some cpu for less pressure
on the garbage collector. The benchmarks show a notable increase in
cpu but allocations are amortized to near zero in many cases.

Internalising the management of scratch buffers simplifies the code and
allows removal/deprecation of duplicate implementations for several functions.

Users will need to re-generate marshaling methods to benefit from the removal
of scratch buffers from those methods.

Benchstat comparison with master:

```
name               old time/op    new time/op    delta
Marshaling-8          564ns ± 1%    1123ns ± 3%   +99.16%  (p=0.000 n=9+10)
Unmarshaling-8       2.75µs ± 5%    3.53µs ± 4%   +28.63%  (p=0.000 n=10+10)
LinkScan-8            744ns ± 0%    1694ns ± 1%  +127.69%  (p=0.000 n=10+9)
Deferred-8           1.68µs ± 1%    3.90µs ± 0%  +131.76%  (p=0.000 n=10+9)
MapMarshaling-8       317ns ± 0%     667ns ± 2%  +110.55%  (p=0.000 n=9+10)
MapUnmarshaling-8    2.71µs ±10%    3.33µs ± 3%   +23.26%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
Marshaling-8           160B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Unmarshaling-8       3.44kB ± 0%    1.96kB ± 0%   -42.94%  (p=0.000 n=10+10)
LinkScan-8             112B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Deferred-8            88.0B ± 0%     72.0B ± 0%   -18.18%  (p=0.000 n=10+10)
MapMarshaling-8       48.0B ± 0%      2.0B ± 0%   -95.83%  (p=0.000 n=10+10)
MapUnmarshaling-8    2.53kB ± 0%    1.54kB ± 0%   -39.15%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
Marshaling-8           10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
Unmarshaling-8         43.0 ± 0%      21.0 ± 0%   -51.16%  (p=0.000 n=10+10)
LinkScan-8             1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Deferred-8             3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
MapMarshaling-8        5.00 ± 0%      2.00 ± 0%   -60.00%  (p=0.000 n=10+10)
MapUnmarshaling-8      56.0 ± 0%      27.0 ± 0%   -51.79%  (p=0.000 n=10+10)
```