### PR TITLE
Add CborReader and CborWriter

### DIFF
--- a/io.go
+++ b/io.go
@@ -1,0 +1,81 @@
+package typegen
+
+import (
+	"io"
+)
+
+var (
+	_ io.Reader      = (*CborReader)(nil)
+	_ io.ByteScanner = (*CborReader)(nil)
+)
+
+type CborReader struct {
+	r    BytePeeker
+	hbuf []byte
+}
+
+func NewCborReader(r io.Reader) *CborReader {
+	if r, ok := r.(*CborReader); ok {
+		return r
+	}
+
+	return &CborReader{
+		r:    GetPeeker(r),
+		hbuf: make([]byte, maxHeaderSize),
+	}
+}
+
+func (cr *CborReader) Read(p []byte) (n int, err error) {
+	return cr.r.Read(p)
+}
+
+func (cr *CborReader) ReadByte() (byte, error) {
+	return cr.r.ReadByte()
+}
+
+func (cr *CborReader) UnreadByte() error {
+	return cr.r.UnreadByte()
+}
+
+func (cr *CborReader) ReadHeader() (byte, uint64, error) {
+	return CborReadHeaderBuf(cr.r, cr.hbuf)
+}
+
+var (
+	_ io.Writer       = (*CborWriter)(nil)
+	_ io.StringWriter = (*CborWriter)(nil)
+)
+
+type CborWriter struct {
+	w    io.Writer
+	hbuf []byte
+}
+
+func NewCborWriter(w io.Writer) *CborWriter {
+	if w, ok := w.(*CborWriter); ok {
+		return w
+	}
+	return &CborWriter{
+		w:    w,
+		hbuf: make([]byte, maxHeaderSize),
+	}
+}
+
+func (cw *CborWriter) Write(p []byte) (n int, err error) {
+	return cw.w.Write(p)
+}
+
+func (cw *CborWriter) WriteMajorTypeHeader(t byte, l uint64) error {
+	return WriteMajorTypeHeaderBuf(cw.hbuf, cw.w, t, l)
+}
+
+func (cw *CborWriter) CborWriteHeader(t byte, l uint64) error {
+	return WriteMajorTypeHeaderBuf(cw.hbuf, cw.w, t, l)
+}
+
+func (cw *CborWriter) WriteString(s string) (int, error) {
+	if sw, ok := cw.w.(io.StringWriter); ok {
+		return sw.WriteString(s)
+	}
+	return cw.w.Write([]byte(s))
+}

--- a/testing/bench_test.go
+++ b/testing/bench_test.go
@@ -58,7 +58,6 @@ func BenchmarkUnmarshaling(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkLinkScan(b *testing.B) {
@@ -113,6 +112,53 @@ func BenchmarkDeferred(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		reader.Seek(0, io.SeekStart)
 		if err := deferred.UnmarshalCBOR(reader); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapMarshaling(b *testing.B) {
+	r := rand.New(rand.NewSource(56887))
+	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
+	if !ok {
+		b.Fatal("failed to construct type")
+	}
+
+	tt := val.Interface().(SimpleTypeTree)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := tt.MarshalCBOR(ioutil.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapUnmarshaling(b *testing.B) {
+	r := rand.New(rand.NewSource(123456))
+	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
+	if !ok {
+		b.Fatal("failed to construct type")
+	}
+
+	tt := val.Interface().(SimpleTypeTree)
+
+	buf := new(bytes.Buffer)
+	if err := tt.MarshalCBOR(buf); err != nil {
+		b.Fatal(err)
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		reader.Seek(0, io.SeekStart)
+		var tt SimpleTypeTree
+		if err := tt.UnmarshalCBOR(reader); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -25,7 +25,10 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufSignedArray); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufSignedArray); err != nil {
 		return err
 	}
 
@@ -34,11 +37,11 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Signed was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Signed))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Signed))); err != nil {
 		return err
 	}
 	for _, v := range t.Signed {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+		if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
 	}
@@ -48,9 +51,9 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SignedArray{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -70,7 +73,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Signed ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -89,7 +92,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeader(br)
+		maj, val, err := cr.ReadHeader()
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Signed slice: %w", err)
 		}
@@ -111,7 +114,10 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufSimpleTypeOne); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufSimpleTypeOne); err != nil {
 		return err
 	}
 
@@ -120,7 +126,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Foo was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Foo))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Foo))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Foo)); err != nil {
@@ -129,7 +135,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -138,21 +144,21 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Binary was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Binary))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.Binary))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.Binary[:]); err != nil {
+	if _, err := cw.Write(t.Binary[:]); err != nil {
 		return err
 	}
 
 	// t.Signed (int64) (int64)
 	if t.Signed >= 0 {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
 			return err
 		}
 	}
@@ -162,7 +168,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NString was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NString))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.NString))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NString)); err != nil {
@@ -174,9 +180,9 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeOne{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -197,7 +203,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Foo (string) (string)
 
 	{
-		sval, err := cbg.ReadString(br)
+		sval, err := cbg.ReadString(cr)
 		if err != nil {
 			return err
 		}
@@ -208,7 +214,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeader(br)
+		maj, extra, err = cr.ReadHeader()
 		if err != nil {
 			return err
 		}
@@ -220,7 +226,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Binary ([]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -236,12 +242,12 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 		t.Binary = make([]uint8, extra)
 	}
 
-	if _, err := io.ReadFull(br, t.Binary[:]); err != nil {
+	if _, err := io.ReadFull(cr, t.Binary[:]); err != nil {
 		return err
 	}
 	// t.Signed (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeader(br)
+		maj, extra, err := cr.ReadHeader()
 		var extraI int64
 		if err != nil {
 			return err
@@ -267,7 +273,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.NString (testing.NamedString) (string)
 
 	{
-		sval, err := cbg.ReadString(br)
+		sval, err := cbg.ReadString(cr)
 		if err != nil {
 			return err
 		}
@@ -284,12 +290,15 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufSimpleTypeTwo); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufSimpleTypeTwo); err != nil {
 		return err
 	}
 
 	// t.Stuff (testing.SimpleTypeTwo) (struct)
-	if err := t.Stuff.MarshalCBOR(w); err != nil {
+	if err := t.Stuff.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -298,11 +307,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+		if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
 	}
@@ -312,16 +321,16 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.SignedOthers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
 		return err
 	}
 	for _, v := range t.SignedOthers {
 		if v >= 0 {
-			if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 				return err
 			}
 		} else {
-			if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-v-1)); err != nil {
 				return err
 			}
 		}
@@ -332,7 +341,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -340,11 +349,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
-		if _, err := w.Write(v[:]); err != nil {
+		if _, err := cw.Write(v[:]); err != nil {
 			return err
 		}
 	}
@@ -354,7 +363,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -366,11 +375,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Numbers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Numbers))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Numbers))); err != nil {
 		return err
 	}
 	for _, v := range t.Numbers {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+		if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
 	}
@@ -378,11 +387,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 	// t.Pizza (uint64) (uint64)
 
 	if t.Pizza == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
 			return err
 		}
 	}
@@ -390,11 +399,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 	// t.PointyPizza (testing.NamedNumber) (uint64)
 
 	if t.PointyPizza == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
 			return err
 		}
 	}
@@ -404,11 +413,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Arrrrrghay was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
 		return err
 	}
 	for _, v := range t.Arrrrrghay {
-		if err := v.MarshalCBOR(w); err != nil {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 	}
@@ -418,9 +427,9 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTwo{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -442,16 +451,16 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		b, err := br.ReadByte()
+		b, err := cr.ReadByte()
 		if err != nil {
 			return err
 		}
 		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
 			t.Stuff = new(SimpleTypeTwo)
-			if err := t.Stuff.UnmarshalCBOR(br); err != nil {
+			if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
 				return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
 			}
 		}
@@ -459,7 +468,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Others ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -478,7 +487,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeader(br)
+		maj, val, err := cr.ReadHeader()
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 		}
@@ -492,7 +501,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.SignedOthers ([]int64) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -511,7 +520,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 		{
-			maj, extra, err := cbg.CborReadHeader(br)
+			maj, extra, err := cr.ReadHeader()
 			var extraI int64
 			if err != nil {
 				return err
@@ -538,7 +547,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Test ([][]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -561,7 +570,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			var extra uint64
 			var err error
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -577,7 +586,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 				t.Test[i] = make([]uint8, extra)
 			}
 
-			if _, err := io.ReadFull(br, t.Test[i][:]); err != nil {
+			if _, err := io.ReadFull(cr, t.Test[i][:]); err != nil {
 				return err
 			}
 		}
@@ -586,7 +595,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Dog (string) (string)
 
 	{
-		sval, err := cbg.ReadString(br)
+		sval, err := cbg.ReadString(cr)
 		if err != nil {
 			return err
 		}
@@ -595,7 +604,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Numbers ([]testing.NamedNumber) (slice)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -614,7 +623,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeader(br)
+		maj, val, err := cr.ReadHeader()
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Numbers slice: %w", err)
 		}
@@ -630,15 +639,15 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		b, err := br.ReadByte()
+		b, err := cr.ReadByte()
 		if err != nil {
 			return err
 		}
 		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -654,15 +663,15 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		b, err := br.ReadByte()
+		b, err := cr.ReadByte()
 		if err != nil {
 			return err
 		}
 		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -676,7 +685,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Arrrrrghay ([3]testing.SimpleTypeOne) (array)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -698,7 +707,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := 0; i < int(extra); i++ {
 
 		var v SimpleTypeOne
-		if err := v.UnmarshalCBOR(br); err != nil {
+		if err := v.UnmarshalCBOR(cr); err != nil {
 			return err
 		}
 
@@ -715,23 +724,26 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDeferredContainer); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufDeferredContainer); err != nil {
 		return err
 	}
 
 	// t.Stuff (testing.SimpleTypeOne) (struct)
-	if err := t.Stuff.MarshalCBOR(w); err != nil {
+	if err := t.Stuff.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
 	// t.Deferred (typegen.Deferred) (struct)
-	if err := t.Deferred.MarshalCBOR(w); err != nil {
+	if err := t.Deferred.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -741,9 +753,9 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = DeferredContainer{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -765,16 +777,16 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		b, err := br.ReadByte()
+		b, err := cr.ReadByte()
 		if err != nil {
 			return err
 		}
 		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
 			t.Stuff = new(SimpleTypeOne)
-			if err := t.Stuff.UnmarshalCBOR(br); err != nil {
+			if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
 				return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
 			}
 		}
@@ -786,7 +798,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 		t.Deferred = new(cbg.Deferred)
 
-		if err := t.Deferred.UnmarshalCBOR(br); err != nil {
+		if err := t.Deferred.UnmarshalCBOR(cr); err != nil {
 			return xerrors.Errorf("failed to read deferred field: %w", err)
 		}
 	}
@@ -794,7 +806,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeader(br)
+		maj, extra, err = cr.ReadHeader()
 		if err != nil {
 			return err
 		}
@@ -814,7 +826,10 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufFixedArrays); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufFixedArrays); err != nil {
 		return err
 	}
 
@@ -823,11 +838,11 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Bytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.Bytes[:]); err != nil {
+	if _, err := cw.Write(t.Bytes[:]); err != nil {
 		return err
 	}
 
@@ -836,11 +851,11 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Uint8 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.Uint8[:]); err != nil {
+	if _, err := cw.Write(t.Uint8[:]); err != nil {
 		return err
 	}
 
@@ -849,11 +864,11 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Uint64 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Uint64))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Uint64))); err != nil {
 		return err
 	}
 	for _, v := range t.Uint64 {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+		if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
 	}
@@ -863,9 +878,9 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = FixedArrays{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -885,7 +900,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Bytes ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -903,12 +918,12 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	t.Bytes = [20]uint8{}
 
-	if _, err := io.ReadFull(br, t.Bytes[:]); err != nil {
+	if _, err := io.ReadFull(cr, t.Bytes[:]); err != nil {
 		return err
 	}
 	// t.Uint8 ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -926,12 +941,12 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	t.Uint8 = [20]uint8{}
 
-	if _, err := io.ReadFull(br, t.Uint8[:]); err != nil {
+	if _, err := io.ReadFull(cr, t.Uint8[:]); err != nil {
 		return err
 	}
 	// t.Uint64 ([20]uint64) (array)
 
-	maj, extra, err = cbg.CborReadHeader(br)
+	maj, extra, err = cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -952,7 +967,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeader(br)
+		maj, val, err := cr.ReadHeader()
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Uint64 slice: %w", err)
 		}
@@ -974,22 +989,25 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufThingWithSomeTime); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufThingWithSomeTime); err != nil {
 		return err
 	}
 
 	// t.When (typegen.CborTime) (struct)
-	if err := t.When.MarshalCBOR(w); err != nil {
+	if err := t.When.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
 	// t.Stuff (int64) (int64)
 	if t.Stuff >= 0 {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
 			return err
 		}
 	}
@@ -999,7 +1017,7 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.CatName was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.CatName))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.CatName))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.CatName)); err != nil {
@@ -1011,9 +1029,9 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = ThingWithSomeTime{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -1035,14 +1053,14 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		if err := t.When.UnmarshalCBOR(br); err != nil {
+		if err := t.When.UnmarshalCBOR(cr); err != nil {
 			return xerrors.Errorf("unmarshaling t.When: %w", err)
 		}
 
 	}
 	// t.Stuff (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeader(br)
+		maj, extra, err := cr.ReadHeader()
 		var extraI int64
 		if err != nil {
 			return err
@@ -1068,7 +1086,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.CatName (string) (string)
 
 	{
-		sval, err := cbg.ReadString(br)
+		sval, err := cbg.ReadString(cr)
 		if err != nil {
 			return err
 		}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -29,14 +29,12 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Signed ([]uint64) (slice)
 	if len(t.Signed) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Signed was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Signed))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Signed))); err != nil {
 		return err
 	}
 	for _, v := range t.Signed {
@@ -51,9 +49,8 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SignedArray{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -73,7 +70,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Signed ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -92,7 +89,7 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Signed slice: %w", err)
 		}
@@ -118,14 +115,12 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Foo (string) (string)
 	if len(t.Foo) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Foo was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Foo))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Foo))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Foo)); err != nil {
@@ -134,7 +129,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -143,7 +138,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Binary was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Binary))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Binary))); err != nil {
 		return err
 	}
 
@@ -153,11 +148,11 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 
 	// t.Signed (int64) (int64)
 	if t.Signed >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Signed)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Signed-1)); err != nil {
 			return err
 		}
 	}
@@ -167,7 +162,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NString was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.NString))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NString))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NString)); err != nil {
@@ -180,9 +175,8 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeOne{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -203,7 +197,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Foo (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -214,7 +208,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err = cbg.CborReadHeader(br)
 		if err != nil {
 			return err
 		}
@@ -226,7 +220,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Binary ([]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -247,7 +241,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Signed (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
 		if err != nil {
 			return err
@@ -273,7 +267,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.NString (testing.NamedString) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -294,8 +288,6 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeTwo) (struct)
 	if err := t.Stuff.MarshalCBOR(w); err != nil {
 		return err
@@ -306,7 +298,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
@@ -320,16 +312,16 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.SignedOthers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.SignedOthers))); err != nil {
 		return err
 	}
 	for _, v := range t.SignedOthers {
 		if v >= 0 {
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
 				return err
 			}
 		} else {
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-v-1)); err != nil {
 				return err
 			}
 		}
@@ -340,7 +332,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -348,7 +340,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
@@ -362,7 +354,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -374,7 +366,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Numbers was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Numbers))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Numbers))); err != nil {
 		return err
 	}
 	for _, v := range t.Numbers {
@@ -390,7 +382,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.Pizza)); err != nil {
 			return err
 		}
 	}
@@ -402,7 +394,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.PointyPizza)); err != nil {
 			return err
 		}
 	}
@@ -412,7 +404,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Arrrrrghay was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Arrrrrghay))); err != nil {
 		return err
 	}
 	for _, v := range t.Arrrrrghay {
@@ -427,9 +419,8 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTwo{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -468,7 +459,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Others ([]uint64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -487,7 +478,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 		}
@@ -501,7 +492,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.SignedOthers ([]int64) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -520,7 +511,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 		{
-			maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err := cbg.CborReadHeader(br)
 			var extraI int64
 			if err != nil {
 				return err
@@ -547,7 +538,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Test ([][]uint8) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -570,7 +561,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			var extra uint64
 			var err error
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -595,7 +586,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.Dog (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}
@@ -604,7 +595,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Numbers ([]testing.NamedNumber) (slice)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -623,7 +614,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Numbers slice: %w", err)
 		}
@@ -647,7 +638,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := br.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -671,7 +662,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := br.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -685,7 +676,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Arrrrrghay ([3]testing.SimpleTypeOne) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -728,8 +719,6 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeOne) (struct)
 	if err := t.Stuff.MarshalCBOR(w); err != nil {
 		return err
@@ -742,7 +731,7 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 
 	// t.Value (uint64) (uint64)
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Value)); err != nil {
 		return err
 	}
 
@@ -753,9 +742,8 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = DeferredContainer{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -806,7 +794,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err = cbg.CborReadHeader(br)
 		if err != nil {
 			return err
 		}
@@ -830,14 +818,12 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Bytes ([20]uint8) (array)
 	if len(t.Bytes) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("Byte array in field t.Bytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Bytes))); err != nil {
 		return err
 	}
 
@@ -850,7 +836,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.Uint8 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.Uint8))); err != nil {
 		return err
 	}
 
@@ -863,7 +849,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Uint64 was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Uint64))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Uint64))); err != nil {
 		return err
 	}
 	for _, v := range t.Uint64 {
@@ -878,9 +864,8 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = FixedArrays{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -900,7 +885,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Bytes ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -923,7 +908,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Uint8 ([20]uint8) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -946,7 +931,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Uint64 ([20]uint64) (array)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err = cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -967,7 +952,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	for i := 0; i < int(extra); i++ {
 
-		maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, val, err := cbg.CborReadHeader(br)
 		if err != nil {
 			return xerrors.Errorf("failed to read uint64 for t.Uint64 slice: %w", err)
 		}
@@ -993,8 +978,6 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.When (typegen.CborTime) (struct)
 	if err := t.When.MarshalCBOR(w); err != nil {
 		return err
@@ -1002,11 +985,11 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 
 	// t.Stuff (int64) (int64)
 	if t.Stuff >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Stuff)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Stuff-1)); err != nil {
 			return err
 		}
 	}
@@ -1016,7 +999,7 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.CatName was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.CatName))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.CatName))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.CatName)); err != nil {
@@ -1029,9 +1012,8 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = ThingWithSomeTime{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1060,7 +1042,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Stuff (int64) (int64)
 	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err := cbg.CborReadHeader(br)
 		var extraI int64
 		if err != nil {
 			return err
@@ -1086,7 +1068,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	// t.CatName (string) (string)
 
 	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
+		sval, err := cbg.ReadString(br)
 		if err != nil {
 			return err
 		}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -23,7 +23,10 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{167}); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{167}); err != nil {
 		return err
 	}
 
@@ -32,14 +35,14 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Stuff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Stuff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stuff")); err != nil {
 		return err
 	}
 
-	if err := t.Stuff.MarshalCBOR(w); err != nil {
+	if err := t.Stuff.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -48,14 +51,14 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Stufff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Stufff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stufff")); err != nil {
 		return err
 	}
 
-	if err := t.Stufff.MarshalCBOR(w); err != nil {
+	if err := t.Stufff.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -64,7 +67,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Others\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Others"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Others"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Others")); err != nil {
@@ -75,11 +78,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
-		if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+		if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
 			return err
 		}
 	}
@@ -89,7 +92,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Test\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Test"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Test"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Test")); err != nil {
@@ -100,7 +103,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -108,11 +111,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
-		if _, err := w.Write(v[:]); err != nil {
+		if _, err := cw.Write(v[:]); err != nil {
 			return err
 		}
 	}
@@ -122,7 +125,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Dog\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Dog"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Dog")); err != nil {
@@ -133,7 +136,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -145,7 +148,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"SixtyThreeBitIntegerWithASignBit\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("SixtyThreeBitIntegerWithASignBit")); err != nil {
@@ -153,11 +156,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.SixtyThreeBitIntegerWithASignBit >= 0 {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
 			return err
 		}
 	}
@@ -167,7 +170,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NotPizza\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NotPizza")); err != nil {
@@ -175,11 +178,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.NotPizza == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
 			return err
 		}
 	}
@@ -190,9 +193,9 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTree{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -216,7 +219,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadString(br)
+			sval, err := cbg.ReadString(cr)
 			if err != nil {
 				return err
 			}
@@ -230,16 +233,16 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
 					t.Stuff = new(SimpleTypeTree)
-					if err := t.Stuff.UnmarshalCBOR(br); err != nil {
+					if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
 					}
 				}
@@ -250,16 +253,16 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
 					t.Stufff = new(SimpleTypeTwo)
-					if err := t.Stufff.UnmarshalCBOR(br); err != nil {
+					if err := t.Stufff.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling t.Stufff pointer: %w", err)
 					}
 				}
@@ -268,7 +271,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Others ([]uint64) (slice)
 		case "Others":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -287,7 +290,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			for i := 0; i < int(extra); i++ {
 
-				maj, val, err := cbg.CborReadHeader(br)
+				maj, val, err := cr.ReadHeader()
 				if err != nil {
 					return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 				}
@@ -302,7 +305,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Test ([][]uint8) (slice)
 		case "Test":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -325,7 +328,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					var extra uint64
 					var err error
 
-					maj, extra, err = cbg.CborReadHeader(br)
+					maj, extra, err = cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -341,7 +344,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 						t.Test[i] = make([]uint8, extra)
 					}
 
-					if _, err := io.ReadFull(br, t.Test[i][:]); err != nil {
+					if _, err := io.ReadFull(cr, t.Test[i][:]); err != nil {
 						return err
 					}
 				}
@@ -351,7 +354,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 		case "Dog":
 
 			{
-				sval, err := cbg.ReadString(br)
+				sval, err := cbg.ReadString(cr)
 				if err != nil {
 					return err
 				}
@@ -361,7 +364,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
 		case "SixtyThreeBitIntegerWithASignBit":
 			{
-				maj, extra, err := cbg.CborReadHeader(br)
+				maj, extra, err := cr.ReadHeader()
 				var extraI int64
 				if err != nil {
 					return err
@@ -389,15 +392,15 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
-					maj, extra, err = cbg.CborReadHeader(br)
+					maj, extra, err = cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -423,7 +426,10 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{161}); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{161}); err != nil {
 		return err
 	}
 
@@ -432,7 +438,7 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Thing\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Thing"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Thing"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Thing")); err != nil {
@@ -448,9 +454,9 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = NeedScratchForMap{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -474,7 +480,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadString(br)
+			sval, err := cbg.ReadString(cr)
 			if err != nil {
 				return err
 			}
@@ -486,7 +492,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Thing (bool) (bool)
 		case "Thing":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -515,7 +521,10 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{167}); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{167}); err != nil {
 		return err
 	}
 
@@ -524,7 +533,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -535,7 +544,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -547,7 +556,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -558,11 +567,11 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.OldBytes[:]); err != nil {
+	if _, err := cw.Write(t.OldBytes[:]); err != nil {
 		return err
 	}
 
@@ -571,14 +580,14 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -587,7 +596,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -595,11 +604,11 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.OldPtr == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(cw, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -609,7 +618,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -621,7 +630,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -637,14 +646,14 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
 				return err
 			}
 
-			if err := v.MarshalCBOR(w); err != nil {
+			if err := v.MarshalCBOR(cw); err != nil {
 				return err
 			}
 
@@ -656,7 +665,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -667,11 +676,11 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
-		if err := v.MarshalCBOR(w); err != nil {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 	}
@@ -681,14 +690,14 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
 		return err
 	}
 
-	if err := t.OldStruct.MarshalCBOR(w); err != nil {
+	if err := t.OldStruct.MarshalCBOR(cw); err != nil {
 		return err
 	}
 	return nil
@@ -697,9 +706,9 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV1{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -723,7 +732,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadString(br)
+			sval, err := cbg.ReadString(cr)
 			if err != nil {
 				return err
 			}
@@ -736,7 +745,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadString(br)
+				sval, err := cbg.ReadString(cr)
 				if err != nil {
 					return err
 				}
@@ -746,7 +755,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -762,7 +771,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 				t.OldBytes = make([]uint8, extra)
 			}
 
-			if _, err := io.ReadFull(br, t.OldBytes[:]); err != nil {
+			if _, err := io.ReadFull(cr, t.OldBytes[:]); err != nil {
 				return err
 			}
 			// t.OldNum (uint64) (uint64)
@@ -770,7 +779,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeader(br)
+				maj, extra, err = cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -785,16 +794,16 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
 
-					c, err := cbg.ReadCid(br)
+					c, err := cbg.ReadCid(cr)
 					if err != nil {
 						return xerrors.Errorf("failed to read cid field t.OldPtr: %w", err)
 					}
@@ -806,7 +815,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -824,7 +833,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadString(br)
+					sval, err := cbg.ReadString(cr)
 					if err != nil {
 						return err
 					}
@@ -836,7 +845,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 				{
 
-					if err := v.UnmarshalCBOR(br); err != nil {
+					if err := v.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling v: %w", err)
 					}
 
@@ -848,7 +857,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -868,7 +877,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			for i := 0; i < int(extra); i++ {
 
 				var v SimpleTypeOne
-				if err := v.UnmarshalCBOR(br); err != nil {
+				if err := v.UnmarshalCBOR(cr); err != nil {
 					return err
 				}
 
@@ -880,7 +889,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				if err := t.OldStruct.UnmarshalCBOR(br); err != nil {
+				if err := t.OldStruct.UnmarshalCBOR(cr); err != nil {
 					return xerrors.Errorf("unmarshaling t.OldStruct: %w", err)
 				}
 
@@ -899,7 +908,10 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{174}); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{174}); err != nil {
 		return err
 	}
 
@@ -908,7 +920,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -919,7 +931,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -931,7 +943,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStr")); err != nil {
@@ -942,7 +954,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NewStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NewStr)); err != nil {
@@ -954,7 +966,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -965,11 +977,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.OldBytes[:]); err != nil {
+	if _, err := cw.Write(t.OldBytes[:]); err != nil {
 		return err
 	}
 
@@ -978,7 +990,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewBytes")); err != nil {
@@ -989,11 +1001,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.NewBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
 		return err
 	}
 
-	if _, err := w.Write(t.NewBytes[:]); err != nil {
+	if _, err := cw.Write(t.NewBytes[:]); err != nil {
 		return err
 	}
 
@@ -1002,14 +1014,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -1018,14 +1030,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewNum"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
 		return err
 	}
 
@@ -1034,7 +1046,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -1042,11 +1054,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.OldPtr == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(cw, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -1056,7 +1068,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewPtr")); err != nil {
@@ -1064,11 +1076,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.NewPtr == nil {
-		if _, err := w.Write(cbg.CborNull); err != nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCid(w, *t.NewPtr); err != nil {
+		if err := cbg.WriteCid(cw, *t.NewPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.NewPtr: %w", err)
 		}
 	}
@@ -1078,7 +1090,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -1090,7 +1102,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -1106,14 +1118,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
 				return err
 			}
 
-			if err := v.MarshalCBOR(w); err != nil {
+			if err := v.MarshalCBOR(cw); err != nil {
 				return err
 			}
 
@@ -1125,7 +1137,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewMap"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewMap")); err != nil {
@@ -1137,7 +1149,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.NewMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.NewMap))); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len(t.NewMap))); err != nil {
 			return err
 		}
 
@@ -1153,14 +1165,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
 				return err
 			}
 
-			if err := v.MarshalCBOR(w); err != nil {
+			if err := v.MarshalCBOR(cw); err != nil {
 				return err
 			}
 
@@ -1172,7 +1184,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -1183,11 +1195,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
-		if err := v.MarshalCBOR(w); err != nil {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 	}
@@ -1197,7 +1209,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewArray"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewArray")); err != nil {
@@ -1208,11 +1220,11 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.NewArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.NewArray))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.NewArray))); err != nil {
 		return err
 	}
 	for _, v := range t.NewArray {
-		if err := v.MarshalCBOR(w); err != nil {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 	}
@@ -1222,14 +1234,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
 		return err
 	}
 
-	if err := t.OldStruct.MarshalCBOR(w); err != nil {
+	if err := t.OldStruct.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1238,14 +1250,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStruct")); err != nil {
 		return err
 	}
 
-	if err := t.NewStruct.MarshalCBOR(w); err != nil {
+	if err := t.NewStruct.MarshalCBOR(cw); err != nil {
 		return err
 	}
 	return nil
@@ -1254,9 +1266,9 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV2{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -1280,7 +1292,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadString(br)
+			sval, err := cbg.ReadString(cr)
 			if err != nil {
 				return err
 			}
@@ -1293,7 +1305,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadString(br)
+				sval, err := cbg.ReadString(cr)
 				if err != nil {
 					return err
 				}
@@ -1304,7 +1316,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "NewStr":
 
 			{
-				sval, err := cbg.ReadString(br)
+				sval, err := cbg.ReadString(cr)
 				if err != nil {
 					return err
 				}
@@ -1314,7 +1326,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1330,13 +1342,13 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				t.OldBytes = make([]uint8, extra)
 			}
 
-			if _, err := io.ReadFull(br, t.OldBytes[:]); err != nil {
+			if _, err := io.ReadFull(cr, t.OldBytes[:]); err != nil {
 				return err
 			}
 			// t.NewBytes ([]uint8) (slice)
 		case "NewBytes":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1352,7 +1364,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				t.NewBytes = make([]uint8, extra)
 			}
 
-			if _, err := io.ReadFull(br, t.NewBytes[:]); err != nil {
+			if _, err := io.ReadFull(cr, t.NewBytes[:]); err != nil {
 				return err
 			}
 			// t.OldNum (uint64) (uint64)
@@ -1360,7 +1372,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeader(br)
+				maj, extra, err = cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -1375,7 +1387,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeader(br)
+				maj, extra, err = cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -1390,16 +1402,16 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
 
-					c, err := cbg.ReadCid(br)
+					c, err := cbg.ReadCid(cr)
 					if err != nil {
 						return xerrors.Errorf("failed to read cid field t.OldPtr: %w", err)
 					}
@@ -1413,16 +1425,16 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				b, err := br.ReadByte()
+				b, err := cr.ReadByte()
 				if err != nil {
 					return err
 				}
 				if b != cbg.CborNull[0] {
-					if err := br.UnreadByte(); err != nil {
+					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
 
-					c, err := cbg.ReadCid(br)
+					c, err := cbg.ReadCid(cr)
 					if err != nil {
 						return xerrors.Errorf("failed to read cid field t.NewPtr: %w", err)
 					}
@@ -1434,7 +1446,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1452,7 +1464,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadString(br)
+					sval, err := cbg.ReadString(cr)
 					if err != nil {
 						return err
 					}
@@ -1464,7 +1476,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 				{
 
-					if err := v.UnmarshalCBOR(br); err != nil {
+					if err := v.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling v: %w", err)
 					}
 
@@ -1476,7 +1488,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewMap (map[string]testing.SimpleTypeOne) (map)
 		case "NewMap":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1494,7 +1506,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadString(br)
+					sval, err := cbg.ReadString(cr)
 					if err != nil {
 						return err
 					}
@@ -1506,7 +1518,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 				{
 
-					if err := v.UnmarshalCBOR(br); err != nil {
+					if err := v.UnmarshalCBOR(cr); err != nil {
 						return xerrors.Errorf("unmarshaling v: %w", err)
 					}
 
@@ -1518,7 +1530,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1538,7 +1550,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			for i := 0; i < int(extra); i++ {
 
 				var v SimpleTypeOne
-				if err := v.UnmarshalCBOR(br); err != nil {
+				if err := v.UnmarshalCBOR(cr); err != nil {
 					return err
 				}
 
@@ -1548,7 +1560,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewArray ([]testing.SimpleTypeOne) (slice)
 		case "NewArray":
 
-			maj, extra, err = cbg.CborReadHeader(br)
+			maj, extra, err = cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1568,7 +1580,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			for i := 0; i < int(extra); i++ {
 
 				var v SimpleTypeOne
-				if err := v.UnmarshalCBOR(br); err != nil {
+				if err := v.UnmarshalCBOR(cr); err != nil {
 					return err
 				}
 
@@ -1580,7 +1592,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				if err := t.OldStruct.UnmarshalCBOR(br); err != nil {
+				if err := t.OldStruct.UnmarshalCBOR(cr); err != nil {
 					return xerrors.Errorf("unmarshaling t.OldStruct: %w", err)
 				}
 
@@ -1590,7 +1602,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				if err := t.NewStruct.UnmarshalCBOR(br); err != nil {
+				if err := t.NewStruct.UnmarshalCBOR(cr); err != nil {
 					return xerrors.Errorf("unmarshaling t.NewStruct: %w", err)
 				}
 
@@ -1609,7 +1621,10 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{162}); err != nil {
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{162}); err != nil {
 		return err
 	}
 
@@ -1618,7 +1633,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"foo\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("foo"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("foo"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("foo")); err != nil {
@@ -1626,11 +1641,11 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.Foo >= 0 {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
 			return err
 		}
 	}
@@ -1640,7 +1655,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"beep\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("beep"))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("beep"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("beep")); err != nil {
@@ -1651,7 +1666,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Bar was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Bar))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Bar))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Bar)); err != nil {
@@ -1663,9 +1678,9 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = RenamedFields{}
 
-	br := cbg.GetPeeker(r)
+	cr := cbg.NewCborReader(r)
 
-	maj, extra, err := cbg.CborReadHeader(br)
+	maj, extra, err := cr.ReadHeader()
 	if err != nil {
 		return err
 	}
@@ -1689,7 +1704,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadString(br)
+			sval, err := cbg.ReadString(cr)
 			if err != nil {
 				return err
 			}
@@ -1701,7 +1716,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Foo (int64) (int64)
 		case "foo":
 			{
-				maj, extra, err := cbg.CborReadHeader(br)
+				maj, extra, err := cr.ReadHeader()
 				var extraI int64
 				if err != nil {
 					return err
@@ -1728,7 +1743,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		case "beep":
 
 			{
-				sval, err := cbg.ReadString(br)
+				sval, err := cbg.ReadString(cr)
 				if err != nil {
 					return err
 				}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -27,14 +27,12 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Stuff (testing.SimpleTypeTree) (struct)
 	if len("Stuff") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"Stuff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stuff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stuff")); err != nil {
@@ -50,7 +48,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Stufff\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Stufff"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Stufff")); err != nil {
@@ -66,7 +64,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Others\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Others"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Others"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Others")); err != nil {
@@ -77,7 +75,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Others was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Others))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Others))); err != nil {
 		return err
 	}
 	for _, v := range t.Others {
@@ -91,7 +89,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Test\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Test"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Test"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Test")); err != nil {
@@ -102,7 +100,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.Test was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Test))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.Test))); err != nil {
 		return err
 	}
 	for _, v := range t.Test {
@@ -110,7 +108,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("Byte array in field v was too long")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(v))); err != nil {
 			return err
 		}
 
@@ -124,7 +122,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"Dog\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Dog"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Dog")); err != nil {
@@ -135,7 +133,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Dog was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Dog))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Dog)); err != nil {
@@ -147,7 +145,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"SixtyThreeBitIntegerWithASignBit\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("SixtyThreeBitIntegerWithASignBit"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("SixtyThreeBitIntegerWithASignBit")); err != nil {
@@ -155,11 +153,11 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.SixtyThreeBitIntegerWithASignBit >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.SixtyThreeBitIntegerWithASignBit)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.SixtyThreeBitIntegerWithASignBit-1)); err != nil {
 			return err
 		}
 	}
@@ -169,7 +167,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NotPizza\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NotPizza"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NotPizza")); err != nil {
@@ -181,7 +179,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(*t.NotPizza)); err != nil {
 			return err
 		}
 	}
@@ -193,9 +191,8 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleTypeTree{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -219,7 +216,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -271,7 +268,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Others ([]uint64) (slice)
 		case "Others":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -290,7 +287,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 
 			for i := 0; i < int(extra); i++ {
 
-				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, val, err := cbg.CborReadHeader(br)
 				if err != nil {
 					return xerrors.Errorf("failed to read uint64 for t.Others slice: %w", err)
 				}
@@ -305,7 +302,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Test ([][]uint8) (slice)
 		case "Test":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -328,7 +325,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					var extra uint64
 					var err error
 
-					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					maj, extra, err = cbg.CborReadHeader(br)
 					if err != nil {
 						return err
 					}
@@ -354,7 +351,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 		case "Dog":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -364,7 +361,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.SixtyThreeBitIntegerWithASignBit (int64) (int64)
 		case "SixtyThreeBitIntegerWithASignBit":
 			{
-				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err := cbg.CborReadHeader(br)
 				var extraI int64
 				if err != nil {
 					return err
@@ -400,7 +397,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					if err := br.UnreadByte(); err != nil {
 						return err
 					}
-					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					maj, extra, err = cbg.CborReadHeader(br)
 					if err != nil {
 						return err
 					}
@@ -430,14 +427,12 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Thing (bool) (bool)
 	if len("Thing") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"Thing\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Thing"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("Thing"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("Thing")); err != nil {
@@ -454,9 +449,8 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = NeedScratchForMap{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -480,7 +474,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -492,7 +486,7 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Thing (bool) (bool)
 		case "Thing":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -525,14 +519,12 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.OldStr (string) (string)
 	if len("OldStr") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -543,7 +535,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -555,7 +547,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -566,7 +558,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
@@ -579,14 +571,14 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -595,7 +587,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -607,7 +599,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -617,7 +609,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -629,7 +621,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -645,7 +637,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -664,7 +656,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -675,7 +667,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
@@ -689,7 +681,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
@@ -706,9 +698,8 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV1{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -732,7 +723,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -745,7 +736,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -755,7 +746,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -779,7 +770,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -815,7 +806,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -833,7 +824,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -857,7 +848,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -912,14 +903,12 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.OldStr (string) (string)
 	if len("OldStr") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"OldStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStr")); err != nil {
@@ -930,7 +919,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.OldStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.OldStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.OldStr)); err != nil {
@@ -942,7 +931,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewStr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStr")); err != nil {
@@ -953,7 +942,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.NewStr was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.NewStr))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.NewStr)); err != nil {
@@ -965,7 +954,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldBytes")); err != nil {
@@ -976,7 +965,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.OldBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.OldBytes))); err != nil {
 		return err
 	}
 
@@ -989,7 +978,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewBytes\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewBytes"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewBytes")); err != nil {
@@ -1000,7 +989,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Byte array in field t.NewBytes was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(t.NewBytes))); err != nil {
 		return err
 	}
 
@@ -1013,14 +1002,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.OldNum)); err != nil {
 		return err
 	}
 
@@ -1029,14 +1018,14 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewNum\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewNum"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewNum"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewNum")); err != nil {
 		return err
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.NewNum)); err != nil {
 		return err
 	}
 
@@ -1045,7 +1034,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldPtr")); err != nil {
@@ -1057,7 +1046,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.OldPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.OldPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.OldPtr: %w", err)
 		}
 	}
@@ -1067,7 +1056,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewPtr\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewPtr"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewPtr")); err != nil {
@@ -1079,7 +1068,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	} else {
-		if err := cbg.WriteCidBuf(scratch, w, *t.NewPtr); err != nil {
+		if err := cbg.WriteCid(w, *t.NewPtr); err != nil {
 			return xerrors.Errorf("failed to write cid field t.NewPtr: %w", err)
 		}
 	}
@@ -1089,7 +1078,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldMap")); err != nil {
@@ -1101,7 +1090,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.OldMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.OldMap))); err != nil {
 			return err
 		}
 
@@ -1117,7 +1106,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -1136,7 +1125,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewMap\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewMap"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewMap"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewMap")); err != nil {
@@ -1148,7 +1137,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 			return xerrors.Errorf("cannot marshal t.NewMap map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.NewMap))); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajMap, uint64(len(t.NewMap))); err != nil {
 			return err
 		}
 
@@ -1164,7 +1153,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 				return xerrors.Errorf("Value in field k was too long")
 			}
 
-			if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(k))); err != nil {
+			if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(k))); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, string(k)); err != nil {
@@ -1183,7 +1172,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldArray")); err != nil {
@@ -1194,7 +1183,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.OldArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.OldArray))); err != nil {
 		return err
 	}
 	for _, v := range t.OldArray {
@@ -1208,7 +1197,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewArray\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewArray"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewArray"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewArray")); err != nil {
@@ -1219,7 +1208,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Slice value in field t.NewArray was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.NewArray))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t.NewArray))); err != nil {
 		return err
 	}
 	for _, v := range t.NewArray {
@@ -1233,7 +1222,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"OldStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("OldStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("OldStruct")); err != nil {
@@ -1249,7 +1238,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"NewStruct\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("NewStruct"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("NewStruct")); err != nil {
@@ -1266,9 +1255,8 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = SimpleStructV2{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1292,7 +1280,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -1305,7 +1293,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "OldStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -1316,7 +1304,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		case "NewStr":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}
@@ -1326,7 +1314,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1348,7 +1336,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewBytes ([]uint8) (slice)
 		case "NewBytes":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1372,7 +1360,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -1387,7 +1375,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err = cbg.CborReadHeader(br)
 				if err != nil {
 					return err
 				}
@@ -1446,7 +1434,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1464,7 +1452,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -1488,7 +1476,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewMap (map[string]testing.SimpleTypeOne) (map)
 		case "NewMap":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1506,7 +1494,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				var k string
 
 				{
-					sval, err := cbg.ReadStringBuf(br, scratch)
+					sval, err := cbg.ReadString(br)
 					if err != nil {
 						return err
 					}
@@ -1530,7 +1518,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1560,7 +1548,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewArray ([]testing.SimpleTypeOne) (slice)
 		case "NewArray":
 
-			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			maj, extra, err = cbg.CborReadHeader(br)
 			if err != nil {
 				return err
 			}
@@ -1625,14 +1613,12 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	scratch := make([]byte, 9)
-
 	// t.Foo (int64) (int64)
 	if len("foo") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"foo\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("foo"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("foo"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("foo")); err != nil {
@@ -1640,11 +1626,11 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 	}
 
 	if t.Foo >= 0 {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
 			return err
 		}
 	} else {
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
+		if err := cbg.WriteMajorTypeHeader(w, cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
 			return err
 		}
 	}
@@ -1654,7 +1640,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field \"beep\" was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("beep"))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len("beep"))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string("beep")); err != nil {
@@ -1665,7 +1651,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("Value in field t.Bar was too long")
 	}
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.Bar))); err != nil {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajTextString, uint64(len(t.Bar))); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, string(t.Bar)); err != nil {
@@ -1678,9 +1664,8 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = RenamedFields{}
 
 	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
 
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	maj, extra, err := cbg.CborReadHeader(br)
 	if err != nil {
 		return err
 	}
@@ -1704,7 +1689,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 	for i := uint64(0); i < n; i++ {
 
 		{
-			sval, err := cbg.ReadStringBuf(br, scratch)
+			sval, err := cbg.ReadString(br)
 			if err != nil {
 				return err
 			}
@@ -1716,7 +1701,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Foo (int64) (int64)
 		case "foo":
 			{
-				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				maj, extra, err := cbg.CborReadHeader(br)
 				var extraI int64
 				if err != nil {
 					return err
@@ -1743,7 +1728,7 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		case "beep":
 
 			{
-				sval, err := cbg.ReadStringBuf(br, scratch)
+				sval, err := cbg.ReadString(br)
 				if err != nil {
 					return err
 				}

--- a/utils.go
+++ b/utils.go
@@ -246,6 +246,8 @@ func readByte(r io.Reader) (byte, error) {
 		return r.ReadByte()
 	case *peeker:
 		return r.ReadByte()
+	case *CborReader:
+		return readByte(r.r)
 	case io.ByteReader:
 		return r.ReadByte()
 	}
@@ -331,6 +333,8 @@ func readByteBuf(r io.Reader, scratch []byte) (byte, error) {
 		return r.ReadByte()
 	case *peeker:
 		return r.ReadByte()
+	case *CborReader:
+		return readByte(r.r)
 	case io.ByteReader:
 		return r.ReadByte()
 	}

--- a/utils.go
+++ b/utils.go
@@ -101,7 +101,6 @@ func ScanForLinks(br io.Reader, cb func(cid.Cid)) (err error) {
 					return fmt.Errorf("string in cbor input too long")
 				}
 
-				scratch := make([]byte, maxCidLength)
 				if _, err := io.ReadAtLeast(br, scratch[:extra], int(extra)); err != nil {
 					return err
 				}

--- a/utils.go
+++ b/utils.go
@@ -632,10 +632,8 @@ func bufToCid(buf []byte) (cid.Cid, error) {
 var byteArrZero = []byte{0}
 
 func WriteCid(w io.Writer, c cid.Cid) error {
-	if cw, ok := w.(*CborWriter); ok {
-		w = cw // take advantage of cbor writer scratch buffer
-	}
-	if err := WriteMajorTypeHeader(w, MajTag, 42); err != nil {
+	cw := NewCborWriter(w)
+	if err := cw.WriteMajorTypeHeader(MajTag, 42); err != nil {
 		return err
 	}
 	if c == cid.Undef {
@@ -643,16 +641,16 @@ func WriteCid(w io.Writer, c cid.Cid) error {
 		// return CborWriteHeader(w, MajByteString, 0)
 	}
 
-	if err := WriteMajorTypeHeader(w, MajByteString, uint64(c.ByteLen()+1)); err != nil {
+	if err := cw.WriteMajorTypeHeader(MajByteString, uint64(c.ByteLen()+1)); err != nil {
 		return err
 	}
 
 	// that binary multibase prefix...
-	if _, err := w.Write(byteArrZero); err != nil {
+	if _, err := cw.Write(byteArrZero); err != nil {
 		return err
 	}
 
-	if _, err := c.WriteBytes(w); err != nil {
+	if _, err := c.WriteBytes(cw); err != nil {
 		return err
 	}
 

--- a/validate.go
+++ b/validate.go
@@ -13,11 +13,8 @@ func ValidateCBOR(b []byte) error {
 
 	br := bytes.NewReader(b)
 
-	// Allocate some scratch space.
-	scratch := make([]byte, maxHeaderSize)
-
 	for remaining := uint64(1); remaining > 0; remaining-- {
-		maj, extra, err := CborReadHeaderBuf(br, scratch)
+		maj, extra, err := CborReadHeader(br)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Gives a better tradeoff between cpu and allocations than #65 so I am closing that PR in favour of this one.

Adds CborReader and CborWriter that contain a small buffer for optimizing CBOR header reads and writes. In contrast to #65 no pool is used for header buffers, instead the reader or writer reuses a single buffer over multiple operations. A package level pool is used for 8k buffers used when reading strings. The benchmarks show an increase in cpu but allocations are substantially reduced.

Benchstat comparison with master:
```
name               old time/op    new time/op    delta
Marshaling-8          564ns ± 1%     840ns ± 0%  +49.06%  (p=0.000 n=9+9)
Unmarshaling-8       2.75µs ± 5%    3.07µs ± 9%  +11.71%  (p=0.000 n=10+10)
LinkScan-8            744ns ± 0%     932ns ± 1%  +25.26%  (p=0.000 n=10+10)
Deferred-8           1.68µs ± 1%    1.89µs ± 2%  +12.57%  (p=0.000 n=10+10)
MapMarshaling-8       317ns ± 0%     441ns ± 0%  +39.21%  (p=0.000 n=9+9)
MapUnmarshaling-8    2.71µs ±10%    3.07µs ±12%  +13.50%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
Marshaling-8           160B ± 0%       64B ± 0%  -60.00%  (p=0.000 n=10+10)
Unmarshaling-8       3.44kB ± 0%    2.03kB ± 0%  -41.08%  (p=0.000 n=10+10)
LinkScan-8             112B ± 0%      112B ± 0%     ~     (all equal)
Deferred-8            88.0B ± 0%     88.0B ± 0%     ~     (all equal)
MapMarshaling-8       48.0B ± 0%     64.0B ± 0%  +33.33%  (p=0.000 n=10+10)
MapUnmarshaling-8    2.53kB ± 0%    1.60kB ± 0%  -36.63%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
Marshaling-8           10.0 ± 0%       2.0 ± 0%  -80.00%  (p=0.000 n=10+10)
Unmarshaling-8         43.0 ± 0%      23.0 ± 0%  -46.51%  (p=0.000 n=10+10)
LinkScan-8             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Deferred-8             3.00 ± 0%      3.00 ± 0%     ~     (all equal)
MapMarshaling-8        5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
MapUnmarshaling-8      56.0 ± 0%      29.0 ± 0%  -48.21%  (p=0.000 n=10+10)
```

There's probably some additional opportunities for refactoring around the reader/writers but I'm leaviing this change focussed on the initial performance improvements.