### PR TITLE
fix: make sure we don't shadow the named return error

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1032,7 +1032,7 @@ func emitCborUnmarshalSliceField(w io.Writer, f Field) error {
 
 func emitCborUnmarshalStructTuple(w io.Writer, gti *GenTypeInfo) error {
 	err := doTemplate(w, gti, `
-func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = {{.Name}}{}
 
 	br := cbg.GetPeeker(r)
@@ -1043,8 +1043,8 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -1196,7 +1196,7 @@ func emitCborMarshalStructMap(w io.Writer, gti *GenTypeInfo) error {
 
 func emitCborUnmarshalStructMap(w io.Writer, gti *GenTypeInfo) error {
 	err := doTemplate(w, gti, `
-func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = {{.Name}}{}
 
 	br := cbg.GetPeeker(r)
@@ -1207,8 +1207,8 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -47,7 +47,7 @@ func (t *SignedArray) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SignedArray) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SignedArray{}
 
 	br := cbg.GetPeeker(r)
@@ -58,8 +58,8 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -176,7 +176,7 @@ func (t *SimpleTypeOne) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SimpleTypeOne{}
 
 	br := cbg.GetPeeker(r)
@@ -187,8 +187,8 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -423,7 +423,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SimpleTypeTwo{}
 
 	br := cbg.GetPeeker(r)
@@ -434,8 +434,8 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -749,7 +749,7 @@ func (t *DeferredContainer) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = DeferredContainer{}
 
 	br := cbg.GetPeeker(r)
@@ -760,8 +760,8 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -874,7 +874,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = FixedArrays{}
 
 	br := cbg.GetPeeker(r)
@@ -885,8 +885,8 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -1025,7 +1025,7 @@ func (t *ThingWithSomeTime) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = ThingWithSomeTime{}
 
 	br := cbg.GetPeeker(r)
@@ -1036,8 +1036,8 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -189,7 +189,7 @@ func (t *SimpleTypeTree) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SimpleTypeTree{}
 
 	br := cbg.GetPeeker(r)
@@ -200,8 +200,8 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -450,7 +450,7 @@ func (t *NeedScratchForMap) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = NeedScratchForMap{}
 
 	br := cbg.GetPeeker(r)
@@ -461,8 +461,8 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -702,7 +702,7 @@ func (t *SimpleStructV1) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SimpleStructV1{}
 
 	br := cbg.GetPeeker(r)
@@ -713,8 +713,8 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -1262,7 +1262,7 @@ func (t *SimpleStructV2) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = SimpleStructV2{}
 
 	br := cbg.GetPeeker(r)
@@ -1273,8 +1273,8 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -1674,7 +1674,7 @@ func (t *RenamedFields) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
+func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (_err error) {
 	*t = RenamedFields{}
 
 	br := cbg.GetPeeker(r)
@@ -1685,8 +1685,8 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 

--- a/utils.go
+++ b/utils.go
@@ -60,11 +60,11 @@ func discard(br io.Reader, n int) error {
 	}
 }
 
-func ScanForLinks(br io.Reader, cb func(cid.Cid)) (err error) {
+func ScanForLinks(br io.Reader, cb func(cid.Cid)) (_err error) {
 	hasReadOnce := false
 	defer func() {
-		if err == io.EOF && hasReadOnce {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF && hasReadOnce {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 	scratch := make([]byte, maxCidLength)
@@ -158,7 +158,7 @@ func (d *Deferred) MarshalCBOR(w io.Writer) error {
 	return err
 }
 
-func (d *Deferred) UnmarshalCBOR(br io.Reader) (err error) {
+func (d *Deferred) UnmarshalCBOR(br io.Reader) (_err error) {
 	// Reuse any existing buffers.
 	reusedBuf := d.Raw[:0]
 	d.Raw = nil
@@ -169,8 +169,8 @@ func (d *Deferred) UnmarshalCBOR(br io.Reader) (err error) {
 
 	hasReadOnce := false
 	defer func() {
-		if err == io.EOF && hasReadOnce {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF && hasReadOnce {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -249,14 +249,14 @@ func readByte(r io.Reader) (byte, error) {
 	return buf[0], err
 }
 
-func CborReadHeader(br io.Reader) (_b byte, _ui uint64, err error) {
+func CborReadHeader(br io.Reader) (_b byte, _ui uint64, _err error) {
 	first, err := readByte(br)
 	if err != nil {
 		return 0, 0, err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 
@@ -477,14 +477,14 @@ func CborEncodeMajorType(t byte, l uint64) []byte {
 	}
 }
 
-func ReadTaggedByteArray(br io.Reader, exptag uint64, maxlen uint64) (bs []byte, err error) {
+func ReadTaggedByteArray(br io.Reader, exptag uint64, maxlen uint64) (_ []byte, _err error) {
 	maj, extra, err := CborReadHeader(br)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
+		if _err == io.EOF {
+			_err = io.ErrUnexpectedEOF
 		}
 	}()
 


### PR DESCRIPTION
Rename the "return" error to _err so we don't accidentally shadow it.