### PR TITLE
Support gen for map with value type `string`

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -491,6 +491,10 @@ func emitCborMarshalMapField(w io.Writer, f Field) error {
 
 	// Map value
 	switch f.Type.Elem().Kind() {
+	case reflect.String:
+		if err := emitCborMarshalStringField(w, Field{Name: "v"}); err != nil {
+			return err
+		}
 	case reflect.Ptr:
 		if f.Type.Elem().Elem().Kind() != reflect.Struct {
 			return fmt.Errorf("unsupported map elem ptr type: %s", f.Type.Elem())
@@ -991,6 +995,20 @@ func emitCborUnmarshalMapField(w io.Writer, f Field) error {
 	var pointer bool
 	t := f.Type.Elem()
 	switch t.Kind() {
+	case reflect.String:
+		if err := doTemplate(w, f, `
+	var v string
+`); err != nil {
+			return err
+		}
+		if err := emitCborUnmarshalStringField(w, Field{Name: "v"}); err != nil {
+			return err
+		}
+		if err := doTemplate(w, f, `
+	{{ .Name }}[k] = v
+`); err != nil {
+			return err
+		}
 	case reflect.Ptr:
 		if t.Elem().Kind() != reflect.Struct {
 			return fmt.Errorf("unsupported map elem ptr type: %s", t)

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
-github.com/mr-tron/base58 v1.1.0 h1:Y51FGVJ91WBqCEabAi5OPUz38eAx8DakuAm5svLcsfQ=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -14,6 +14,8 @@ func main() {
 		types.FixedArrays{},
 		types.ThingWithSomeTime{},
 		types.BigField{},
+		// TODO this fails with error: failed to generate encoders: currently unsupported map elem type: string
+		types.MapStringString{},
 	); err != nil {
 		panic(err)
 	}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -14,8 +14,6 @@ func main() {
 		types.FixedArrays{},
 		types.ThingWithSomeTime{},
 		types.BigField{},
-		// TODO this fails with error: failed to generate encoders: currently unsupported map elem type: string
-		types.MapStringString{},
 	); err != nil {
 		panic(err)
 	}
@@ -29,6 +27,7 @@ func main() {
 		types.TestEmpty{},
 		types.TestConstField{},
 		types.TestCanonicalFieldOrder{},
+		types.MapStringString{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -2435,3 +2435,161 @@ func (t *TestCanonicalFieldOrder) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
+func (t *MapStringString) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{161}); err != nil {
+		return err
+	}
+
+	// t.Snorkleblump (map[string]string) (map)
+	if len("Snorkleblump") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Snorkleblump\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("Snorkleblump"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Snorkleblump")); err != nil {
+		return err
+	}
+
+	{
+		if len(t.Snorkleblump) > 4096 {
+			return xerrors.Errorf("cannot marshal t.Snorkleblump map too large")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len(t.Snorkleblump))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(t.Snorkleblump))
+		for k := range t.Snorkleblump {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := t.Snorkleblump[k]
+
+			if len(k) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(k)); err != nil {
+				return err
+			}
+
+			if len(v) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field v was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(v)); err != nil {
+				return err
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *MapStringString) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = MapStringString{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("MapStringString: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Snorkleblump (map[string]string) (map)
+		case "Snorkleblump":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajMap {
+				return fmt.Errorf("expected a map (major type 5)")
+			}
+			if extra > 4096 {
+				return fmt.Errorf("t.Snorkleblump: map too large")
+			}
+
+			t.Snorkleblump = make(map[string]string, extra)
+
+			for i, l := 0, int(extra); i < l; i++ {
+
+				var k string
+
+				{
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					k = string(sval)
+				}
+
+				var v string
+
+				{
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					v = string(sval)
+				}
+
+				t.Snorkleblump[k] = v
+
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ipfs/go-cid"
 
 	"github.com/google/go-cmp/cmp"
+
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
@@ -402,6 +403,37 @@ func TestConstRoundtrip(t *testing.T) {
 	fmt.Printf("%x\n", buf.Bytes())
 
 	var out TestConstField
+	if err := out.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(out)
+}
+
+func TestMapOfStringToString(t *testing.T) {
+	mss := &MapStringString{Snorkleblump: map[string]string{
+		"leave me":    "like this",
+		"RAT":         "ATA",
+		"Tears":       "eyes",
+		"Rumble":      "killers in the jungle",
+		"Butterflies": "caterpillars",
+		"Inhale":      "Exhale",
+		"A Street":    "I know",
+		"XENA":        "ahhhhhhhhhh",
+		"TOO":         "BIZARRE",
+		"Stay":        "Hydrated",
+		"Good":        "Space",
+		"Super":       "sonic",
+		"Hazel":       "theme",
+		"Still":       "Here with the ones that I came with",
+	}}
+
+	buf := new(bytes.Buffer)
+	if err := mss.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var out MapStringString
 	if err := out.UnmarshalCBOR(buf); err != nil {
 		t.Fatal(err)
 	}

--- a/testing/types.go
+++ b/testing/types.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"github.com/ipfs/go-cid"
+
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
@@ -128,4 +129,8 @@ type TestCanonicalFieldOrder struct {
 	Bar   string `cborgen:"beep"`
 	Drond int64
 	Zp    string `cborgen:"ap"`
+}
+
+type MapStringString struct {
+	Snorkleblump map[string]string
 }


### PR DESCRIPTION
Adds test cases and support for map with value type `string`. 