### PR TITLE
gen: custom marshaler

### DIFF
--- a/testgen/main.go
+++ b/testgen/main.go
@@ -27,6 +27,7 @@ func main() {
 		types.TestEmpty{},
 		types.TestConstField{},
 		types.TestCanonicalFieldOrder{},
+		types.CustomMarshalerContainer{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -335,7 +335,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSimpleTypeTwo = []byte{137}
+var lengthBufSimpleTypeTwo = []byte{138}
 
 func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -473,6 +473,11 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
+
+	// t.Custom (testing.CustomMarshalerStruct) (struct)
+	if err := t.Custom.MarshalCBOR(cw); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -495,7 +500,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 9 {
+	if extra != 10 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -766,6 +771,15 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 		t.Arrrrrghay[i] = v
 	}
 
+	// t.Custom (testing.CustomMarshalerStruct) (struct)
+
+	{
+
+		if err := t.Custom.UnmarshalCBOR(cr); err != nil {
+			return xerrors.Errorf("unmarshaling t.Custom: %w", err)
+		}
+
+	}
 	return nil
 }
 

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -410,3 +410,40 @@ func TestConstRoundtrip(t *testing.T) {
 }
 
 //TODO same for strings
+
+func TestCustomMarshalerStruct(t *testing.T) {
+	// Test that a custom marshaler on a struct is called
+	// when the struct is a field of another struct
+	// (i.e. the custom marshaler is not ignored because
+	// the struct is not the top-level value)
+
+	s := &CustomMarshalerContainer{
+		Struct: &CustomMarshalerStruct{
+			Foo: 42,
+			Bar: "hello world",
+		},
+	}
+	buf := new(bytes.Buffer)
+	if err := s.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("%x\n", buf.Bytes())
+
+	var out CustomMarshalerContainer
+	if err := out.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(out)
+
+	if out.Struct.Foo != 42 {
+		t.Fatal("foo not equal")
+	}
+
+	if out.Struct.Bar != "hello world" {
+		t.Fatal("bar not equal")
+	}
+
+	fmt.Printf("%+v, %+v\n", s.Struct, out.Struct)
+}


### PR DESCRIPTION
Custom marshaler support on codegen using reflect's interface implementation check. Ref: https://github.com/bluesky-social/indigo/pull/153

The codegen now checks custom marshaler/unmarshaler implementation for the fields of struct maps and struct tuples. When present, the codegen uses the existing methods instead of generating a new one. 