### PR TITLE
Transparent encoding

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -87,6 +87,10 @@ var _ = sort.Sort
 `)
 }
 
+// FieldNameSelf is the name of the field that is the marshal target itself.
+// This is used in non-struct types which are handled like transparent structs.
+const FieldNameSelf = "."
+
 type Field struct {
 	Name    string
 	MapKey  string
@@ -189,7 +193,7 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 			Transparent: true,
 			Fields: []Field{
 				{
-					Name:        ".",
+					Name:        FieldNameSelf,
 					MapKey:      "",
 					Pointer:     t.Kind() == reflect.Ptr,
 					Type:        t,
@@ -741,7 +745,7 @@ func (t *{{ .Name }}) MarshalCBOR(w io.Writer) error {
 	}
 
 	for _, f := range gti.Fields {
-		if f.Name == "." {
+		if f.Name == FieldNameSelf {
 			f.Name = "(*t)"
 		} else {
 			f.Name = "t." + f.Name
@@ -1513,7 +1517,7 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	for _, f := range gti.Fields {
-		if f.Name == "." {
+		if f.Name == FieldNameSelf {
 			f.Name = "(*t)" // self
 		} else {
 			f.Name = "t." + f.Name

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -14,6 +14,9 @@ func main() {
 		types.FixedArrays{},
 		types.ThingWithSomeTime{},
 		types.BigField{},
+		types.IntArray{},
+		types.IntAliasArray{},
+		types.TupleIntArray{},
 	); err != nil {
 		panic(err)
 	}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -17,6 +17,9 @@ func main() {
 		types.IntArray{},
 		types.IntAliasArray{},
 		types.TupleIntArray{},
+		types.IntArrayNewType{},
+		types.IntArrayAliasNewType{},
+		types.MapTransparentType{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -1297,3 +1297,341 @@ func (t *BigField) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
+
+func (t *IntArray) MarshalCBOR(w io.Writer) error {
+
+	cw := cbg.NewCborWriter(w)
+
+	// t.Ints ([]int64) (slice)
+	if len(t.Ints) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Ints was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Ints))); err != nil {
+		return err
+	}
+	for _, v := range t.Ints {
+		if v >= 0 {
+			if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		} else {
+			if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (t *IntArray) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = IntArray{}
+
+	cr := cbg.NewCborReader(r)
+
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+
+	// t.Ints ([]int64) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Ints: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Ints = make([]int64, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Ints[i] = int64(extraI)
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *IntAliasArray) MarshalCBOR(w io.Writer) error {
+
+	cw := cbg.NewCborWriter(w)
+
+	// t.Ints ([]testing.IntAlias) (slice)
+	if len(t.Ints) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Ints was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Ints))); err != nil {
+		return err
+	}
+	for _, v := range t.Ints {
+		if v >= 0 {
+			if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		} else {
+			if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (t *IntAliasArray) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = IntAliasArray{}
+
+	cr := cbg.NewCborReader(r)
+
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+
+	// t.Ints ([]testing.IntAlias) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Ints: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Ints = make([]IntAlias, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Ints[i] = IntAlias(extraI)
+			}
+
+		}
+	}
+	return nil
+}
+
+var lengthBufTupleIntArray = []byte{131}
+
+func (t *TupleIntArray) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufTupleIntArray); err != nil {
+		return err
+	}
+
+	// t.Int1 (int64) (int64)
+	if t.Int1 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int1)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int1-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Int2 (int64) (int64)
+	if t.Int2 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int2)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int2-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Int3 (int64) (int64)
+	if t.Int3 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int3)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int3-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *TupleIntArray) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = TupleIntArray{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Int1 (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int1 = int64(extraI)
+	}
+	// t.Int2 (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int2 = int64(extraI)
+	}
+	// t.Int3 (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int3 = int64(extraI)
+	}
+	return nil
+}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -1299,7 +1299,6 @@ func (t *BigField) UnmarshalCBOR(r io.Reader) (err error) {
 }
 
 func (t *IntArray) MarshalCBOR(w io.Writer) error {
-
 	cw := cbg.NewCborWriter(w)
 
 	// t.Ints ([]int64) (slice)
@@ -1329,12 +1328,10 @@ func (t *IntArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArray{}
 
 	cr := cbg.NewCborReader(r)
-
 	var maj byte
 	var extra uint64
 	_ = maj
 	_ = extra
-
 	// t.Ints ([]int64) (slice)
 
 	maj, extra, err = cr.ReadHeader()
@@ -1393,7 +1390,6 @@ func (t *IntArray) UnmarshalCBOR(r io.Reader) (err error) {
 }
 
 func (t *IntAliasArray) MarshalCBOR(w io.Writer) error {
-
 	cw := cbg.NewCborWriter(w)
 
 	// t.Ints ([]testing.IntAlias) (slice)
@@ -1423,12 +1419,10 @@ func (t *IntAliasArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntAliasArray{}
 
 	cr := cbg.NewCborReader(r)
-
 	var maj byte
 	var extra uint64
 	_ = maj
 	_ = extra
-
 	// t.Ints ([]testing.IntAlias) (slice)
 
 	maj, extra, err = cr.ReadHeader()
@@ -1637,7 +1631,6 @@ func (t *TupleIntArray) UnmarshalCBOR(r io.Reader) (err error) {
 }
 
 func (t *IntArrayNewType) MarshalCBOR(w io.Writer) error {
-
 	cw := cbg.NewCborWriter(w)
 
 	// (*t) (testing.IntArrayNewType) (slice)
@@ -1667,12 +1660,10 @@ func (t *IntArrayNewType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArrayNewType{}
 
 	cr := cbg.NewCborReader(r)
-
 	var maj byte
 	var extra uint64
 	_ = maj
 	_ = extra
-
 	// (*t) (testing.IntArrayNewType) (slice)
 
 	maj, extra, err = cr.ReadHeader()
@@ -1731,7 +1722,6 @@ func (t *IntArrayNewType) UnmarshalCBOR(r io.Reader) (err error) {
 }
 
 func (t *IntArrayAliasNewType) MarshalCBOR(w io.Writer) error {
-
 	cw := cbg.NewCborWriter(w)
 
 	// (*t) (testing.IntArrayAliasNewType) (slice)
@@ -1761,12 +1751,10 @@ func (t *IntArrayAliasNewType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArrayAliasNewType{}
 
 	cr := cbg.NewCborReader(r)
-
 	var maj byte
 	var extra uint64
 	_ = maj
 	_ = extra
-
 	// (*t) (testing.IntArrayAliasNewType) (slice)
 
 	maj, extra, err = cr.ReadHeader()
@@ -1825,7 +1813,6 @@ func (t *IntArrayAliasNewType) UnmarshalCBOR(r io.Reader) (err error) {
 }
 
 func (t *MapTransparentType) MarshalCBOR(w io.Writer) error {
-
 	cw := cbg.NewCborWriter(w)
 
 	// (*t) (testing.MapTransparentType) (map)
@@ -1877,12 +1864,10 @@ func (t *MapTransparentType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = MapTransparentType{}
 
 	cr := cbg.NewCborReader(r)
-
 	var maj byte
 	var extra uint64
 	_ = maj
 	_ = extra
-
 	// (*t) (testing.MapTransparentType) (map)
 
 	maj, extra, err = cr.ReadHeader()

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -1635,3 +1635,295 @@ func (t *TupleIntArray) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+func (t *IntArrayNewType) MarshalCBOR(w io.Writer) error {
+
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (testing.IntArrayNewType) (slice)
+	if len((*t)) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if v >= 0 {
+			if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		} else {
+			if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (t *IntArrayNewType) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = IntArrayNewType{}
+
+	cr := cbg.NewCborReader(r)
+
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+
+	// (*t) (testing.IntArrayNewType) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]int64, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				(*t)[i] = int64(extraI)
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *IntArrayAliasNewType) MarshalCBOR(w io.Writer) error {
+
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (testing.IntArrayAliasNewType) (slice)
+	if len((*t)) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if v >= 0 {
+			if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		} else {
+			if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-v-1)); err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (t *IntArrayAliasNewType) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = IntArrayAliasNewType{}
+
+	cr := cbg.NewCborReader(r)
+
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+
+	// (*t) (testing.IntArrayAliasNewType) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]IntAlias, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				(*t)[i] = IntAlias(extraI)
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *MapTransparentType) MarshalCBOR(w io.Writer) error {
+
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (testing.MapTransparentType) (map)
+	{
+		if len((*t)) > 4096 {
+			return xerrors.Errorf("cannot marshal (*t) map too large")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len((*t)))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len((*t)))
+		for k := range *t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := (*t)[k]
+
+			if len(k) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(k)); err != nil {
+				return err
+			}
+
+			if len(v) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field v was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(v)); err != nil {
+				return err
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *MapTransparentType) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = MapTransparentType{}
+
+	cr := cbg.NewCborReader(r)
+
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+
+	// (*t) (testing.MapTransparentType) (map)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("expected a map (major type 5)")
+	}
+	if extra > 4096 {
+		return fmt.Errorf("(*t): map too large")
+	}
+
+	(*t) = make(map[string]string, extra)
+
+	for i, l := 0, int(extra); i < l; i++ {
+
+		var k string
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			k = string(sval)
+		}
+
+		var v string
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			v = string(sval)
+		}
+
+		(*t)[k] = v
+
+	}
+	return nil
+}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -494,4 +494,74 @@ func TestTransparentIntArray(t *testing.T) {
 			t.Fatal("mismatch")
 		}
 	})
+
+	// IntArrayNewType / IntArrayAliasNewType
+	t.Run("roundtrip IntArrayNewType", func(t *testing.T) {
+		zero := &IntArrayNewType{}
+		recepticle := &IntArrayNewType{}
+		testValueRoundtrip(t, zero, recepticle)
+	})
+	t.Run("roundtrip IntArrayAliasNewType", func(t *testing.T) {
+		zero := &IntArrayAliasNewType{}
+		recepticle := &IntArrayAliasNewType{}
+		testValueRoundtrip(t, zero, recepticle)
+	})
+	t.Run("roundtrip non-zero IntArrayNewType", func(t *testing.T) {
+		val := &IntArrayNewType{1, 2, 3}
+		recepticle := &IntArrayNewType{}
+		testValueRoundtrip(t, val, recepticle)
+	})
+	t.Run("roundtrip non-zero IntArrayAliasNewType", func(t *testing.T) {
+		val := &IntArrayAliasNewType{1, 2, 3}
+		recepticle := &IntArrayAliasNewType{}
+		testValueRoundtrip(t, val, recepticle)
+	})
+	// NewTypes into/from TupleIntArray
+	t.Run("roundtrip IntArrayNewType to TupleIntArray", func(t *testing.T) {
+		val := IntArrayNewType{1, 2, 3}
+		recepticle := &TupleIntArray{}
+		testValueRoundtrip(t, &val, recepticle)
+		if val[0] != recepticle.Int1 {
+			t.Fatal("mismatch")
+		}
+	})
+	t.Run("roundtrip IntArrayAliasNewType to TupleIntArray", func(t *testing.T) {
+		val := IntArrayAliasNewType{1, 2, 3}
+		recepticle := &TupleIntArray{}
+		testValueRoundtrip(t, &val, recepticle)
+		if int64(val[0]) != recepticle.Int1 {
+			t.Fatal("mismatch")
+		}
+	})
+	t.Run("roundtrip TupleIntArray to IntArrayNewType", func(t *testing.T) {
+		val := TupleIntArray{2, 4, 5}
+		recepticle := IntArrayNewType{}
+		testValueRoundtrip(t, &val, &recepticle)
+		if val.Int1 != recepticle[0] {
+			t.Fatal("mismatch")
+		}
+	})
+	t.Run("roundtrip TupleIntArray to IntArrayAliasNewType", func(t *testing.T) {
+		val := TupleIntArray{2, 4, 5}
+		recepticle := IntArrayAliasNewType{}
+		testValueRoundtrip(t, &val, &recepticle)
+		if val.Int1 != int64(recepticle[0]) {
+			t.Fatal("mismatch")
+		}
+	})
+}
+
+func TestMapTransparentType(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		zero := MapTransparentType{}
+		recepticle := &MapTransparentType{}
+		testValueRoundtrip(t, &zero, recepticle)
+	})
+
+	// non-zero values
+	t.Run("roundtrip non-zero", func(t *testing.T) {
+		val := MapTransparentType(map[string]string{"foo": "bar"})
+		recepticle := &MapTransparentType{}
+		testValueRoundtrip(t, &val, recepticle)
+	})
 }

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -451,3 +451,47 @@ func TestMapOfStringToString(t *testing.T) {
 }
 
 //TODO same for strings
+
+func TestTransparentIntArray(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		zero := &IntArray{}
+		recepticle := &IntArray{}
+		testValueRoundtrip(t, zero, recepticle)
+	})
+
+	t.Run("roundtrip intalias", func(t *testing.T) {
+		zero := &IntAliasArray{}
+		recepticle := &IntAliasArray{}
+		testValueRoundtrip(t, zero, recepticle)
+	})
+
+	// non-zero values
+	t.Run("roundtrip non-zero", func(t *testing.T) {
+		val := &IntArray{Ints: []int64{1, 2, 3}}
+		recepticle := &IntArray{}
+		testValueRoundtrip(t, val, recepticle)
+	})
+	t.Run("roundtrip non-zero intalias", func(t *testing.T) {
+		val := &IntAliasArray{Ints: []IntAlias{1, 2, 3}}
+		recepticle := &IntAliasArray{}
+		testValueRoundtrip(t, val, recepticle)
+	})
+
+	// tuple struct to/from transparent int array
+	t.Run("roundtrip tuple struct to transparent", func(t *testing.T) {
+		val := &TupleIntArray{2, 4, 5}
+		recepticle := &IntArray{}
+		testValueRoundtrip(t, val, recepticle)
+		if val.Int1 != recepticle.Ints[0] {
+			t.Fatal("mismatch")
+		}
+	})
+	t.Run("roundtrip transparent to tuple struct", func(t *testing.T) {
+		val := &IntArray{Ints: []int64{2, 4, 5}}
+		recepticle := &TupleIntArray{}
+		testValueRoundtrip(t, val, recepticle)
+		if val.Ints[0] != recepticle.Int1 {
+			t.Fatal("mismatch")
+		}
+	})
+}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -53,8 +53,25 @@ func TestNilPreserveWorks(t *testing.T) {
 	testTypeRoundtrips(t, reflect.TypeOf(TestSliceNilPreserve{}))
 }
 
-func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmarshaler) {
+type RoundTripOptions struct {
+	Golden []byte
+}
+
+type RoundTripOption func(*RoundTripOptions)
+
+func WithGolden(golden []byte) RoundTripOption {
+	return func(opts *RoundTripOptions) {
+		opts.Golden = golden
+	}
+}
+
+func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmarshaler, options ...RoundTripOption) {
 	t.Helper()
+
+	opts := &RoundTripOptions{}
+	for _, option := range options {
+		option(opts)
+	}
 
 	buf := new(bytes.Buffer)
 	if err := obj.MarshalCBOR(buf); err != nil {
@@ -62,6 +79,12 @@ func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmars
 	}
 
 	enc := buf.Bytes()
+
+	if opts.Golden != nil {
+		if !bytes.Equal(opts.Golden, enc) {
+			t.Fatalf("encoding mismatch: %x != %x", opts.Golden, enc)
+		}
+	}
 
 	if err := nobj.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
 		t.Logf("got bad bytes: %x", enc)
@@ -456,20 +479,20 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip", func(t *testing.T) {
 		zero := &IntArray{}
 		recepticle := &IntArray{}
-		testValueRoundtrip(t, zero, recepticle)
+		testValueRoundtrip(t, zero, recepticle, WithGolden([]byte{0x80}))
 	})
 
 	t.Run("roundtrip intalias", func(t *testing.T) {
 		zero := &IntAliasArray{}
 		recepticle := &IntAliasArray{}
-		testValueRoundtrip(t, zero, recepticle)
+		testValueRoundtrip(t, zero, recepticle, WithGolden([]byte{0x80}))
 	})
 
 	// non-zero values
 	t.Run("roundtrip non-zero", func(t *testing.T) {
 		val := &IntArray{Ints: []int64{1, 2, 3}}
 		recepticle := &IntArray{}
-		testValueRoundtrip(t, val, recepticle)
+		testValueRoundtrip(t, val, recepticle, WithGolden([]byte{0x83, 0x01, 0x02, 0x03}))
 	})
 	t.Run("roundtrip non-zero intalias", func(t *testing.T) {
 		val := &IntAliasArray{Ints: []IntAlias{1, 2, 3}}
@@ -481,7 +504,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip tuple struct to transparent", func(t *testing.T) {
 		val := &TupleIntArray{2, 4, 5}
 		recepticle := &IntArray{}
-		testValueRoundtrip(t, val, recepticle)
+		testValueRoundtrip(t, val, recepticle, WithGolden([]byte{0x83, 0x02, 0x04, 0x05}))
 		if val.Int1 != recepticle.Ints[0] {
 			t.Fatal("mismatch")
 		}
@@ -489,7 +512,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip transparent to tuple struct", func(t *testing.T) {
 		val := &IntArray{Ints: []int64{2, 4, 5}}
 		recepticle := &TupleIntArray{}
-		testValueRoundtrip(t, val, recepticle)
+		testValueRoundtrip(t, val, recepticle, WithGolden([]byte{0x83, 0x02, 0x04, 0x05}))
 		if val.Ints[0] != recepticle.Int1 {
 			t.Fatal("mismatch")
 		}
@@ -499,7 +522,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip IntArrayNewType", func(t *testing.T) {
 		zero := &IntArrayNewType{}
 		recepticle := &IntArrayNewType{}
-		testValueRoundtrip(t, zero, recepticle)
+		testValueRoundtrip(t, zero, recepticle, WithGolden([]byte{0x80}))
 	})
 	t.Run("roundtrip IntArrayAliasNewType", func(t *testing.T) {
 		zero := &IntArrayAliasNewType{}
@@ -509,18 +532,18 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip non-zero IntArrayNewType", func(t *testing.T) {
 		val := &IntArrayNewType{1, 2, 3}
 		recepticle := &IntArrayNewType{}
-		testValueRoundtrip(t, val, recepticle)
+		testValueRoundtrip(t, val, recepticle, WithGolden([]byte{0x83, 0x01, 0x02, 0x03}))
 	})
 	t.Run("roundtrip non-zero IntArrayAliasNewType", func(t *testing.T) {
 		val := &IntArrayAliasNewType{1, 2, 3}
 		recepticle := &IntArrayAliasNewType{}
-		testValueRoundtrip(t, val, recepticle)
+		testValueRoundtrip(t, val, recepticle, WithGolden([]byte{0x83, 0x01, 0x02, 0x03}))
 	})
 	// NewTypes into/from TupleIntArray
 	t.Run("roundtrip IntArrayNewType to TupleIntArray", func(t *testing.T) {
 		val := IntArrayNewType{1, 2, 3}
 		recepticle := &TupleIntArray{}
-		testValueRoundtrip(t, &val, recepticle)
+		testValueRoundtrip(t, &val, recepticle, WithGolden([]byte{0x83, 0x01, 0x02, 0x03}))
 		if val[0] != recepticle.Int1 {
 			t.Fatal("mismatch")
 		}
@@ -528,7 +551,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip IntArrayAliasNewType to TupleIntArray", func(t *testing.T) {
 		val := IntArrayAliasNewType{1, 2, 3}
 		recepticle := &TupleIntArray{}
-		testValueRoundtrip(t, &val, recepticle)
+		testValueRoundtrip(t, &val, recepticle, WithGolden([]byte{0x83, 0x01, 0x02, 0x03}))
 		if int64(val[0]) != recepticle.Int1 {
 			t.Fatal("mismatch")
 		}
@@ -536,7 +559,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip TupleIntArray to IntArrayNewType", func(t *testing.T) {
 		val := TupleIntArray{2, 4, 5}
 		recepticle := IntArrayNewType{}
-		testValueRoundtrip(t, &val, &recepticle)
+		testValueRoundtrip(t, &val, &recepticle, WithGolden([]byte{0x83, 0x02, 0x04, 0x05}))
 		if val.Int1 != recepticle[0] {
 			t.Fatal("mismatch")
 		}
@@ -544,7 +567,7 @@ func TestTransparentIntArray(t *testing.T) {
 	t.Run("roundtrip TupleIntArray to IntArrayAliasNewType", func(t *testing.T) {
 		val := TupleIntArray{2, 4, 5}
 		recepticle := IntArrayAliasNewType{}
-		testValueRoundtrip(t, &val, &recepticle)
+		testValueRoundtrip(t, &val, &recepticle, WithGolden([]byte{0x83, 0x02, 0x04, 0x05}))
 		if val.Int1 != int64(recepticle[0]) {
 			t.Fatal("mismatch")
 		}
@@ -555,13 +578,13 @@ func TestMapTransparentType(t *testing.T) {
 	t.Run("roundtrip", func(t *testing.T) {
 		zero := MapTransparentType{}
 		recepticle := &MapTransparentType{}
-		testValueRoundtrip(t, &zero, recepticle)
+		testValueRoundtrip(t, &zero, recepticle, WithGolden([]byte{0xa0}))
 	})
 
 	// non-zero values
 	t.Run("roundtrip non-zero", func(t *testing.T) {
 		val := MapTransparentType(map[string]string{"foo": "bar"})
 		recepticle := &MapTransparentType{}
-		testValueRoundtrip(t, &val, recepticle)
+		testValueRoundtrip(t, &val, recepticle, WithGolden([]byte{0xa1, 0x63, 0x66, 0x6f, 0x6f, 0x63, 0x62, 0x61, 0x72}))
 	})
 }

--- a/testing/types.go
+++ b/testing/types.go
@@ -155,8 +155,14 @@ type IntAliasArray struct {
 	Ints []IntAlias `cborgen:"transparent"`
 }
 
+type IntArrayNewType []int64
+
+type IntArrayAliasNewType []IntAlias
+
 type TupleIntArray struct {
 	Int1 int64
 	Int2 int64
 	Int3 int64
 }
+
+type MapTransparentType map[string]string

--- a/testing/types.go
+++ b/testing/types.go
@@ -145,3 +145,18 @@ type TestSliceNilPreserve struct {
 	NotOther []byte `cborgen:"preservenil"`
 	Beep     int64
 }
+
+type IntAlias int64
+
+type IntArray struct {
+	Ints []int64 `cborgen:"transparent"`
+}
+type IntAliasArray struct {
+	Ints []IntAlias `cborgen:"transparent"`
+}
+
+type TupleIntArray struct {
+	Int1 int64
+	Int2 int64
+	Int3 int64
+}


### PR DESCRIPTION
This PR adds support for 'transparent' encoding, either in structs with `cborgen:"transparent"` tag (which can be used with other tags), or by just defining a newtype that isn't a struct

```go
type IntAlias int64

type IntArray struct {
	Ints []int64 `cborgen:"transparent"`
}
type IntAliasArray struct {
	Ints []IntAlias `cborgen:"transparent"`
}

type IntArrayNewType []int64

type IntArrayAliasNewType []IntAlias

type MapTransparentType map[string]string
```

Opinions this is based on:
* Transparent encoders can only be generated in tuple mode
  *  Map mode entries have name prefixes, so technically tuple mode makes more sense
* Only one transparent entry in structs with transparent entries
  * Technically we could allow multiple entries, in any case we're just stripping the array header, but that will make things like encoding structs with multiple transparent entries in maps/arrays much more complicated, so just one transparent entry for now
