### PR TITLE
Typo fix: unmarshaling to unmarshalling

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -975,12 +975,12 @@ func (g Gen) emitCborUnmarshalStructField(w io.Writer, f Field) error {
 			}
 			{{ .Name }} = new({{ .TypeName }})
 			if err := {{ .Name }}.UnmarshalCBOR(cr); err != nil {
-				return xerrors.Errorf("unmarshaling {{ .Name }} pointer: %w", err)
+				return xerrors.Errorf("unmarshalling {{ .Name }} pointer: %w", err)
 			}
 		}
 {{ else }}
 		if err := {{ .Name }}.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling {{ .Name }}: %w", err)
+			return xerrors.Errorf("unmarshalling {{ .Name }}: %w", err)
 		}
 {{ end }}
 	}

--- a/testing/bench_test.go
+++ b/testing/bench_test.go
@@ -13,7 +13,7 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
-func BenchmarkMarshaling(b *testing.B) {
+func BenchmarkMarshalling(b *testing.B) {
 	r := rand.New(rand.NewSource(56887))
 	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTwo{}), r)
 	if !ok {
@@ -32,7 +32,7 @@ func BenchmarkMarshaling(b *testing.B) {
 	}
 }
 
-func BenchmarkUnmarshaling(b *testing.B) {
+func BenchmarkUnmarshalling(b *testing.B) {
 	r := rand.New(rand.NewSource(123456))
 	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTwo{}), r)
 	if !ok {
@@ -117,7 +117,7 @@ func BenchmarkDeferred(b *testing.B) {
 	}
 }
 
-func BenchmarkMapMarshaling(b *testing.B) {
+func BenchmarkMapMarshalling(b *testing.B) {
 	r := rand.New(rand.NewSource(56887))
 	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
 	if !ok {
@@ -136,7 +136,7 @@ func BenchmarkMapMarshaling(b *testing.B) {
 	}
 }
 
-func BenchmarkMapUnmarshaling(b *testing.B) {
+func BenchmarkMapUnmarshalling(b *testing.B) {
 	r := rand.New(rand.NewSource(123456))
 	val, ok := quick.Value(reflect.TypeOf(SimpleTypeTree{}), r)
 	if !ok {

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -541,7 +541,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			}
 			t.Stuff = new(SimpleTypeTwo)
 			if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
-				return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
+				return xerrors.Errorf("unmarshalling t.Stuff pointer: %w", err)
 			}
 		}
 
@@ -825,7 +825,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			{
 
 				if err := t.Arrrrrghay[i].UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.Arrrrrghay[i]: %w", err)
+					return xerrors.Errorf("unmarshalling t.Arrrrrghay[i]: %w", err)
 				}
 
 			}
@@ -905,7 +905,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 			}
 			t.Stuff = new(SimpleTypeOne)
 			if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
-				return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
+				return xerrors.Errorf("unmarshalling t.Stuff pointer: %w", err)
 			}
 		}
 
@@ -1178,7 +1178,7 @@ func (t *ThingWithSomeTime) UnmarshalCBOR(r io.Reader) (err error) {
 	{
 
 		if err := t.When.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.When: %w", err)
+			return xerrors.Errorf("unmarshalling t.When: %w", err)
 		}
 
 	}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -359,7 +359,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 					t.Stuff = new(SimpleTypeTree)
 					if err := t.Stuff.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling t.Stuff pointer: %w", err)
+						return xerrors.Errorf("unmarshalling t.Stuff pointer: %w", err)
 					}
 				}
 
@@ -423,7 +423,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 					t.Stufff = new(SimpleTypeTwo)
 					if err := t.Stufff.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling t.Stufff pointer: %w", err)
+						return xerrors.Errorf("unmarshalling t.Stufff pointer: %w", err)
 					}
 				}
 
@@ -957,7 +957,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 				{
 
 					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+						return xerrors.Errorf("unmarshalling v: %w", err)
 					}
 
 				}
@@ -1046,7 +1046,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 					{
 
 						if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+							return xerrors.Errorf("unmarshalling t.OldArray[i]: %w", err)
 						}
 
 					}
@@ -1082,7 +1082,7 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			{
 
 				if err := t.OldStruct.UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.OldStruct: %w", err)
+					return xerrors.Errorf("unmarshalling t.OldStruct: %w", err)
 				}
 
 			}
@@ -1623,7 +1623,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				{
 
 					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+						return xerrors.Errorf("unmarshalling v: %w", err)
 					}
 
 				}
@@ -1714,7 +1714,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 				{
 
 					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+						return xerrors.Errorf("unmarshalling v: %w", err)
 					}
 
 				}
@@ -1803,7 +1803,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 					{
 
 						if err := t.NewArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.NewArray[i]: %w", err)
+							return xerrors.Errorf("unmarshalling t.NewArray[i]: %w", err)
 						}
 
 					}
@@ -1865,7 +1865,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 					{
 
 						if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+							return xerrors.Errorf("unmarshalling t.OldArray[i]: %w", err)
 						}
 
 					}
@@ -1901,7 +1901,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			{
 
 				if err := t.NewStruct.UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.NewStruct: %w", err)
+					return xerrors.Errorf("unmarshalling t.NewStruct: %w", err)
 				}
 
 			}
@@ -1911,7 +1911,7 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			{
 
 				if err := t.OldStruct.UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.OldStruct: %w", err)
+					return xerrors.Errorf("unmarshalling t.OldStruct: %w", err)
 				}
 
 			}

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -76,7 +76,7 @@ func testValueRoundtrip(t *testing.T, obj cbg.CBORMarshaler, nobj cbg.CBORUnmars
 
 	buf := new(bytes.Buffer)
 	if err := obj.MarshalCBOR(buf); err != nil {
-		t.Fatal("i guess its fine to fail marshaling")
+		t.Fatal("i guess its fine to fail marshalling")
 	}
 
 	enc := buf.Bytes()
@@ -130,7 +130,7 @@ func TestDeferredContainer(t *testing.T) {
 	testValueRoundtrip(t, zero, recepticle)
 }
 
-func TestNilValueDeferredUnmarshaling(t *testing.T) {
+func TestNilValueDeferredUnmarshalling(t *testing.T) {
 	var zero DeferredContainer
 	zero.Deferred = &cbg.Deferred{Raw: []byte{0xf6}}
 
@@ -221,7 +221,7 @@ func TestLessToMoreFieldsRoundTrip(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	if err := obj.MarshalCBOR(buf); err != nil {
-		t.Fatal("failed marshaling", err)
+		t.Fatal("failed marshalling", err)
 	}
 
 	enc := buf.Bytes()
@@ -318,7 +318,7 @@ func TestMoreToLessFieldsRoundTrip(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	if err := obj.MarshalCBOR(buf); err != nil {
-		t.Fatal("failed marshaling", err)
+		t.Fatal("failed marshalling", err)
 	}
 
 	enc := buf.Bytes()


### PR DESCRIPTION
Changes all `unmarshaling` to `unmarshalling`

Related issue: https://github.com/filecoin-project/venus/pull/6332
![](https://github.com/filecoin-project/venus/assets/97331552/13b06677-5916-457a-a383-02c3617a1abd)