### PR TITLE
Change ioutil to io

### DIFF
--- a/links.go
+++ b/links.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 
 	cid "github.com/ipfs/go-cid"
@@ -115,7 +114,7 @@ func discard(br io.Reader, n int) error {
 		}
 		return err
 	default:
-		discarded, err := io.CopyN(ioutil.Discard, br, int64(n))
+		discarded, err := io.CopyN(io.Discard, br, int64(n))
 		if discarded != 0 && discarded < int64(n) && err == io.EOF {
 			return io.ErrUnexpectedEOF
 		}

--- a/testing/bench_test.go
+++ b/testing/bench_test.go
@@ -3,7 +3,6 @@ package testing
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -26,7 +25,7 @@ func BenchmarkMarshaling(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if err := tt.MarshalCBOR(ioutil.Discard); err != nil {
+		if err := tt.MarshalCBOR(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -130,7 +129,7 @@ func BenchmarkMapMarshaling(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if err := tt.MarshalCBOR(ioutil.Discard); err != nil {
+		if err := tt.MarshalCBOR(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
`ioutil` is deprecated as of Go 1.16, this value is simply [io.Discard](https://pkg.go.dev/io#Discard).
> https://pkg.go.dev/io/ioutil