### PR TITLE
fix: reject negative big integers

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -440,6 +440,9 @@ func (g Gen) emitCborMarshalStructField(w io.Writer, f Field) error {
 	case bigIntType:
 		return g.doTemplate(w, f, `
 	{
+		if {{ .Name }} != nil && {{ .Name }}.Sign() < 0 {
+			return xerrors.Errorf("Value in field {{ .Name | js }} was a negative big-integer (not supported)")
+		}
 		if err := cw.CborWriteHeader(cbg.MajTag, 2); err != nil {
 			return err
 		}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -21,6 +21,7 @@ func main() {
 		types.IntArrayNewType{},
 		types.IntArrayAliasNewType{},
 		types.MapTransparentType{},
+		types.BigIntContainer{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/types.go
+++ b/testing/types.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"math/big"
 	"math/rand"
 	"reflect"
 
@@ -193,4 +194,8 @@ func (ls LongString) Generate(rand *rand.Rand, size int) reflect.Value {
 	rand.Read(s)
 	ols.Val = string(s)
 	return reflect.ValueOf(ols).Elem()
+}
+
+type BigIntContainer struct {
+	Int *big.Int
 }


### PR DESCRIPTION
We don't encode the sign, so we should reject these numbers.