### PR TITLE
improve allocations in map serialization

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1874,7 +1874,9 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 
 		if !ok {
 			// Field doesn't exist on this type, so ignore it
-			cbg.ScanForLinks(cr, func(cid.Cid){})
+			if err := cbg.ScanForLinks(cr, func(cid.Cid){}); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -1947,7 +1949,9 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 	return g.doTemplate(w, gti, `
 		default:
 			// Field doesn't exist on this type, so ignore it
-			cbg.ScanForLinks(r, func(cid.Cid){})
+			if err := cbg.ScanForLinks(r, func(cid.Cid){}); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/gen.go
+++ b/gen.go
@@ -220,6 +220,16 @@ func (gti *GenTypeInfo) Imports() []Import {
 	return imports
 }
 
+func (gti *GenTypeInfo) MaxMapKeyLength() int {
+	var mlen int
+	for _, f := range gti.Fields {
+		if len(f.MapKey) > mlen {
+			mlen = len(f.MapKey)
+		}
+	}
+	return mlen
+}
+
 func nameIsExported(name string) bool {
 	return strings.ToUpper(name[0:1]) == name[0:1]
 }
@@ -1853,21 +1863,28 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("{{ .Name }}: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, {{ .MaxMapKeyLength }})
 	for i := uint64(0); i < n; i++ {
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, {{ MaxLen 0 "String" }})
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid){})
+			continue
+		}
+
 `)
 	if err != nil {
 		return err
 	}
 
-	if err := g.emitCborUnmarshalStringField(w, Field{Name: "name"}); err != nil {
-		return err
-	}
-
 	err = g.doTemplate(w, gti, `
-		switch name {
+		switch string(nameBuf[:nameLen]) {
 `)
 	if err != nil {
 		return err

--- a/io.go
+++ b/io.go
@@ -1,10 +1,7 @@
 package typegen
 
 import (
-	"fmt"
 	"io"
-
-	cid "github.com/ipfs/go-cid"
 )
 
 var (
@@ -45,42 +42,6 @@ func (cr *CborReader) ReadHeader() (byte, uint64, error) {
 
 func (cr *CborReader) SetReader(r io.Reader) {
 	cr.r = GetPeeker(r)
-}
-
-func (cr *CborReader) ReadCid(scratchBuf []byte) (cid.Cid, error) {
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return cid.Undef, err
-	}
-
-	if maj != MajTag {
-		return cid.Undef, fmt.Errorf("expected cbor type 'tag' in input")
-	}
-
-	if extra != 42 {
-		return cid.Undef, fmt.Errorf("expected tag 42")
-	}
-
-	if extra > 512 {
-		return cid.Undef, fmt.Errorf("header size too big for a cid")
-	}
-
-	if len(scratchBuf) < int(extra) {
-		return cid.Undef, fmt.Errorf("scratchBuf not large enough for cid")
-	}
-
-	_, err = io.ReadFull(cr, scratchBuf[:extra])
-	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return cid.Undef, err
-	}
-
-	return bufToCid(scratchBuf[:extra])
 }
 
 var (

--- a/io.go
+++ b/io.go
@@ -68,7 +68,11 @@ func (cr *CborReader) ReadCid(scratchBuf []byte) (cid.Cid, error) {
 		return cid.Undef, fmt.Errorf("header size too big for a cid")
 	}
 
-	_, err = io.ReadAtLeast(cr, scratchBuf[:extra], int(extra))
+	if len(scratchBuf) < int(extra) {
+		return cid.Undef, fmt.Errorf("scratchBuf not large enough for cid")
+	}
+
+	_, err = io.ReadFull(cr, scratchBuf[:extra])
 	if err != nil {
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF

--- a/peeker.go
+++ b/peeker.go
@@ -22,7 +22,7 @@ func GetPeeker(r io.Reader) BytePeeker {
 type peeker struct {
 	reader    io.Reader
 	peekState int
-	lastByte  byte
+	lastByte  [1]byte
 }
 
 const (
@@ -42,7 +42,7 @@ func (p *peeker) Read(buf []byte) (n int, err error) {
 	}
 
 	if p.peekState == peekUnread {
-		buf[0] = p.lastByte
+		buf[0] = p.lastByte[0]
 		n, err = p.reader.Read(buf[1:])
 		n += 1
 	} else {
@@ -50,7 +50,7 @@ func (p *peeker) Read(buf []byte) (n int, err error) {
 	}
 	if n > 0 {
 		p.peekState = peekSet
-		p.lastByte = buf[n-1]
+		p.lastByte[0] = buf[n-1]
 	}
 	return n, err
 }
@@ -58,30 +58,13 @@ func (p *peeker) Read(buf []byte) (n int, err error) {
 func (p *peeker) ReadByte() (byte, error) {
 	if p.peekState == peekUnread {
 		p.peekState = peekSet
-		return p.lastByte, nil
+		return p.lastByte[0], nil
 	}
-	var buf [1]byte
-	_, err := io.ReadFull(p.reader, buf[:])
+	_, err := io.ReadFull(p.reader, p.lastByte[:])
 	if err != nil {
 		return 0, err
 	}
-	b := buf[0]
-	p.lastByte = b
-	p.peekState = peekSet
-	return b, nil
-}
-
-func (p *peeker) ReadByteBuf(buf []byte) (byte, error) {
-	if p.peekState == peekUnread {
-		p.peekState = peekSet
-		return p.lastByte, nil
-	}
-	_, err := io.ReadFull(p.reader, buf[:1])
-	if err != nil {
-		return 0, err
-	}
-	b := buf[0]
-	p.lastByte = b
+	b := p.lastByte[0]
 	p.peekState = peekSet
 	return b, nil
 }

--- a/peeker.go
+++ b/peeker.go
@@ -71,6 +71,21 @@ func (p *peeker) ReadByte() (byte, error) {
 	return b, nil
 }
 
+func (p *peeker) ReadByteBuf(buf []byte) (byte, error) {
+	if p.peekState == peekUnread {
+		p.peekState = peekSet
+		return p.lastByte, nil
+	}
+	_, err := io.ReadFull(p.reader, buf[:1])
+	if err != nil {
+		return 0, err
+	}
+	b := buf[0]
+	p.lastByte = b
+	p.peekState = peekSet
+	return b, nil
+}
+
 func (p *peeker) UnreadByte() error {
 	if p.peekState != peekSet {
 		return bufio.ErrInvalidUnreadByte

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -38,6 +38,7 @@ func main() {
 		types.MapStringString{},
 		types.TestSliceNilPreserve{},
 		types.StringPtrSlices{},
+		types.FieldNameOverlap{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -267,21 +267,22 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("SimpleTypeTree: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 32)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Dog (string) (string)
 		case "Dog":
 
@@ -595,21 +596,22 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("NeedScratchForMap: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 5)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Thing (bool) (bool)
 		case "Thing":
 
@@ -908,21 +910,22 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("SimpleStructV1: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 14)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
@@ -1574,21 +1577,22 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("SimpleStructV2: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 9)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.NewMap (map[string]testing.SimpleTypeOne) (map)
 		case "NewMap":
 
@@ -2006,21 +2010,22 @@ func (t *RenamedFields) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("RenamedFields: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 4)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Foo (int64) (int64)
 		case "foo":
 			{
@@ -2193,21 +2198,22 @@ func (t *TestEmpty) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("TestEmpty: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 4)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Cat (int64) (int64)
 		case "Cat":
 			{
@@ -2354,21 +2360,22 @@ func (t *TestConstField) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("TestConstField: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 5)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Cats (string) (string)
 		case "Cats":
 
@@ -2543,21 +2550,22 @@ func (t *TestCanonicalFieldOrder) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("TestCanonicalFieldOrder: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 5)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Zp (string) (string)
 		case "ap":
 
@@ -2732,21 +2740,22 @@ func (t *MapStringString) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("MapStringString: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 12)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Snorkleblump (map[string]string) (map)
 		case "Snorkleblump":
 
@@ -3002,21 +3011,22 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("TestSliceNilPreserve: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 8)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Cat (string) (string)
 		case "Cat":
 
@@ -3327,21 +3337,22 @@ func (t *StringPtrSlices) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("StringPtrSlices: map struct too large (%d)", extra)
 	}
 
-	var name string
 	n := extra
 
+	nameBuf := make([]byte, 10)
 	for i := uint64(0); i < n; i++ {
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			name = string(sval)
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
 		}
 
-		switch name {
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
 		// t.Strings ([]string) (slice)
 		case "Strings":
 
@@ -3431,6 +3442,184 @@ func (t *StringPtrSlices) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 
 				}
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *FieldNameOverlap) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{163}); err != nil {
+		return err
+	}
+
+	// t.Foo (int64) (int64)
+	if len("foo") > 8192 {
+		return xerrors.Errorf("Value in field \"foo\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("foo"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("foo")); err != nil {
+		return err
+	}
+
+	if t.Foo >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Foo)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Foo-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Bar (string) (string)
+	if len("beep") > 8192 {
+		return xerrors.Errorf("Value in field \"beep\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("beep"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("beep")); err != nil {
+		return err
+	}
+
+	if len(t.Bar) > 8192 {
+		return xerrors.Errorf("Value in field t.Bar was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Bar))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.Bar)); err != nil {
+		return err
+	}
+
+	// t.LongerNamedField (string) (string)
+	if len("LongerNamedField") > 8192 {
+		return xerrors.Errorf("Value in field \"LongerNamedField\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("LongerNamedField"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("LongerNamedField")); err != nil {
+		return err
+	}
+
+	if len(t.LongerNamedField) > 8192 {
+		return xerrors.Errorf("Value in field t.LongerNamedField was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.LongerNamedField))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.LongerNamedField)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *FieldNameOverlap) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = FieldNameOverlap{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("FieldNameOverlap: map struct too large (%d)", extra)
+	}
+
+	n := extra
+
+	nameBuf := make([]byte, 16)
+	for i := uint64(0); i < n; i++ {
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(cr, func(cid.Cid) {})
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
+		// t.Foo (int64) (int64)
+		case "foo":
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				var extraI int64
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Foo = int64(extraI)
+			}
+			// t.Bar (string) (string)
+		case "beep":
+
+			{
+				sval, err := cbg.ReadStringWithMax(cr, 8192)
+				if err != nil {
+					return err
+				}
+
+				t.Bar = string(sval)
+			}
+			// t.LongerNamedField (string) (string)
+		case "LongerNamedField":
+
+			{
+				sval, err := cbg.ReadStringWithMax(cr, 8192)
+				if err != nil {
+					return err
+				}
+
+				t.LongerNamedField = string(sval)
 			}
 
 		default:

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -789,3 +789,25 @@ func TestStringPtrSlices(t *testing.T) {
 func ptr[T any](v T) *T {
 	return &v
 }
+
+func TestUnmarshalExtraFields(t *testing.T) {
+	in := &FieldNameOverlap{
+		LongerNamedField: "some stuff",
+		Foo:              1825,
+		Bar:              "less things",
+	}
+
+	buf := new(bytes.Buffer)
+	if err := in.MarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var out RenamedFields
+	if err := out.UnmarshalCBOR(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Foo != in.Foo || out.Bar != in.Bar {
+		t.Fatal("encoding mismatch")
+	}
+}

--- a/testing/types.go
+++ b/testing/types.go
@@ -115,6 +115,12 @@ type RenamedFields struct {
 	Bar string `cborgen:"beep"`
 }
 
+type FieldNameOverlap struct {
+	LongerNamedField string
+	Foo              int64  `cborgen:"foo"`
+	Bar              string `cborgen:"beep"`
+}
+
 type BigField struct {
 	LargeBytes []byte `cborgen:"maxlen=10000000"`
 }

--- a/utils.go
+++ b/utils.go
@@ -138,7 +138,7 @@ func readByteBuf(r io.Reader, scratch []byte) (byte, error) {
 	case *bufio.Reader:
 		return r.ReadByte()
 	case *peeker:
-		return r.ReadByteBuf(scratch)
+		return r.ReadByte()
 	case *CborReader:
 		return readByte(r.r)
 	case io.ByteReader:
@@ -432,9 +432,9 @@ func ReadFullStringIntoBuf(cr *CborReader, buf []byte, maxLength uint64) (int, b
 		return 0, false, nil
 	}
 
-	_, err = io.ReadAtLeast(cr, buf[:l], int(l))
+	n, err := io.ReadFull(cr, buf[:l])
 	if err != nil {
-		return 0, false, err
+		return n, false, err
 	}
 
 	return int(l), true, nil

--- a/utils.go
+++ b/utils.go
@@ -427,9 +427,8 @@ func ReadFullStringIntoBuf(cr *CborReader, buf []byte, maxLength uint64) (int, b
 	}
 
 	if l > uint64(len(buf)) {
-		_, err := io.CopyN(io.Discard, cr, int64(l))
-		if err != nil {
-			return 0, false, err
+		if err := discard(cr, int(l)); err != nil {
+			return 0, false, nil
 		}
 		return 0, false, nil
 	}

--- a/utils.go
+++ b/utils.go
@@ -410,6 +410,8 @@ func ReadStringWithMax(r io.Reader, maxLength uint64) (string, error) {
 // ReadFullStringIntoBuf will read a string off the given stream, consuming the
 // entire cbor item if the string on the stream is longer than the buffer,
 // the string is discarded and 'false' is returned
+// Note: Will only read data into the buffer if the data fits into the buffer,
+// otherwise the bytes are discarded entirely
 func ReadFullStringIntoBuf(cr *CborReader, buf []byte, maxLength uint64) (int, bool, error) {
 	maj, l, err := cr.ReadHeader()
 	if err != nil {


### PR DESCRIPTION
reuse buffers more and use optimized read paths when available. 

Before:
```
why@sirius ~/c/cbor-gen (master)> go test ./testing -run XXX -bench=.
goos: linux
goarch: amd64
pkg: github.com/whyrusleeping/cbor-gen/testing
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor
BenchmarkMarshaling-64         	 1856397	       712.1 ns/op	      48 B/op	       1 allocs/op
BenchmarkUnmarshaling-64       	  199536	      6274 ns/op	    1777 B/op	      21 allocs/op
BenchmarkLinkScan-64           	  729843	      1645 ns/op	     112 B/op	       1 allocs/op
BenchmarkDeferred-64           	  505626	      2223 ns/op	      40 B/op	       2 allocs/op
BenchmarkMapMarshaling-64      	 2326390	       497.8 ns/op	      50 B/op	       3 allocs/op
BenchmarkMapUnmarshaling-64    	  140995	      8113 ns/op	    2043 B/op	      36 allocs/op
PASS
ok  	github.com/whyrusleeping/cbor-gen/testing	10.424s
```

After:
```
why@sirius ~/c/cbor-gen (master)> go test ./testing -run XXX -bench=.
goos: linux
goarch: amd64
pkg: github.com/whyrusleeping/cbor-gen/testing
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor
BenchmarkMarshaling-64         	 1755950	       722.5 ns/op	      48 B/op	       1 allocs/op
BenchmarkUnmarshaling-64       	  192193	      6699 ns/op	    1777 B/op	      21 allocs/op
BenchmarkLinkScan-64           	  672280	      1669 ns/op	     112 B/op	       1 allocs/op
BenchmarkDeferred-64           	  656348	      2182 ns/op	      40 B/op	       2 allocs/op
BenchmarkMapMarshaling-64      	 2236473	       536.9 ns/op	      50 B/op	       3 allocs/op
BenchmarkMapUnmarshaling-64    	  183109	      6313 ns/op	    1930 B/op	      20 allocs/op
PASS
ok  	github.com/whyrusleeping/cbor-gen/testing	8.893s
```