### PR TITLE
Infer the maximum permitted length of Array from its length

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -311,7 +311,15 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 				return nil, fmt.Errorf("maxsize tag value was not valid: %w", err)
 			}
 
+			if f.Type.Kind() == reflect.Array && val > f.Type.Len() {
+				return nil, fmt.Errorf("maxlen tag value was larger than array length")
+			}
+
 			usrMaxLen = val
+		} else if f.Type.Kind() == reflect.Array {
+			// Override the max length for arrays to be the array length if no explicit
+			// length is specified.
+			usrMaxLen = f.Type.Len()
 		}
 
 		var constval *string

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -490,7 +490,7 @@ func (t *SimpleTypeTwo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Arrrrrghay ([3]testing.SimpleTypeOne) (array)
-	if len(t.Arrrrrghay) > 8192 {
+	if len(t.Arrrrrghay) > 3 {
 		return xerrors.Errorf("Slice value in field t.Arrrrrghay was too long")
 	}
 
@@ -802,7 +802,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 8192 {
+	if extra > 3 {
 		return fmt.Errorf("t.Arrrrrghay: array too large (%d)", extra)
 	}
 
@@ -953,7 +953,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Bytes ([20]uint8) (array)
-	if len(t.Bytes) > 2097152 {
+	if len(t.Bytes) > 20 {
 		return xerrors.Errorf("Byte array in field t.Bytes was too long")
 	}
 
@@ -966,7 +966,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Uint8 ([20]uint8) (array)
-	if len(t.Uint8) > 2097152 {
+	if len(t.Uint8) > 20 {
 		return xerrors.Errorf("Byte array in field t.Uint8 was too long")
 	}
 
@@ -979,7 +979,7 @@ func (t *FixedArrays) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Uint64 ([20]uint64) (array)
-	if len(t.Uint64) > 8192 {
+	if len(t.Uint64) > 20 {
 		return xerrors.Errorf("Slice value in field t.Uint64 was too long")
 	}
 
@@ -1026,7 +1026,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 20 {
 		return fmt.Errorf("t.Bytes: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
@@ -1047,7 +1047,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 20 {
 		return fmt.Errorf("t.Uint8: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
@@ -1068,7 +1068,7 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 8192 {
+	if extra > 20 {
 		return fmt.Errorf("t.Uint64: array too large (%d)", extra)
 	}
 


### PR DESCRIPTION
When no `maxlen` struct tag is specified, the generator uses a set of built-in default maximum lengths:
 * 2<<12 for string, array/slice length, and
 * 2<<20 for maximum byte array/slice length.

But the underlying type kind `reflect.Array` allows the generator to pick maximum lengths more defensively. This results in a more robust generated code where invalid values are rejected earlier, before they're unnecessarily read beyond the length of the array to which they correspond.

When a field is of type `reflect.Array`:
 * if `maxlen` struct tag is set: check that the maximum length does not exceed the array length.
 * otherwise, use the array length as the maximum permitted length for the field.

This change has a subtle side effect: before this, any CBOR value that exceeded its underlying array length was being silently accepted, and re-sliced at runtime to fit into the type representation. But now the generated code would out right reject such values as "too long".