### PR TITLE
feat: add support for optional fields at the end of tuple structs

### DIFF
--- a/testgen/main.go
+++ b/testgen/main.go
@@ -22,6 +22,7 @@ func main() {
 		types.IntArrayAliasNewType{},
 		types.MapTransparentType{},
 		types.BigIntContainer{},
+		types.TupleWithOptionalFields{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -2197,3 +2197,200 @@ func (t *BigIntContainer) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+var lengthBufTupleWithOptionalFields = []byte{132}
+
+func (t *TupleWithOptionalFields) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufTupleWithOptionalFields); err != nil {
+		return err
+	}
+
+	// t.Int1 (int64) (int64)
+	if t.Int1 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int1)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int1-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Int2 (int64) (int64)
+	if t.Int2 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int2)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int2-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Int3 (int64) (int64)
+	if t.Int3 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int3)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int3-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Int4 (int64) (int64)
+	if t.Int4 >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int4)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int4-1)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *TupleWithOptionalFields) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = TupleWithOptionalFields{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra > 4 {
+		return fmt.Errorf("cbor input has too many fields %d > 4", extra)
+	}
+
+	if extra < 2 {
+		return fmt.Errorf("cbor input has too few fields %d < 2", extra)
+	}
+
+	// t.Int1 (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		var extraI int64
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int1 = int64(extraI)
+	}
+	// t.Int2 (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		var extraI int64
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int2 = int64(extraI)
+	}
+	// t.Int3 (int64) (int64)
+	if extra < 3 {
+		return nil
+	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		var extraI int64
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int3 = int64(extraI)
+	}
+	// t.Int4 (int64) (int64)
+	if extra < 4 {
+		return nil
+	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		var extraI int64
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Int4 = int64(extraI)
+	}
+	return nil
+}

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -29,15 +29,20 @@ func TestOptionalFields(t *testing.T) {
 				fallthrough
 			case 3:
 				if out.Int3 != ints[2] {
-					t.Errorf("field 4 should be %d, was %d", ints[3], out.Int4)
+					t.Errorf("field 3 should be %d, was %d", ints[2], out.Int3)
 				}
 				fallthrough
 			case 2:
 				if out.Int2 != ints[1] {
-					t.Errorf("field 4 should be %d, was %d", ints[1], out.Int2)
+					t.Errorf("field 2 should be %d, was %d", ints[1], out.Int2)
 				}
 				if out.Int1 != ints[0] {
-					t.Errorf("field 4 should be %d, was %d", ints[0], out.Int1)
+					t.Errorf("field 1 should be %d, was %d", ints[0], out.Int1)
+				}
+				if (count == 4 || count == 3) && out.Int4 != 0 {
+					t.Errorf("expected field 4 to be zero")
+				} else if count == 3 && out.Int3 != 0 {
+					t.Errorf("expected field 3 to be zero")
 				}
 				if err != nil {
 					t.Errorf("expected no error when unmarshaling, got: %s", err)

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -46,10 +46,16 @@ func TestOptionalFields(t *testing.T) {
 				if out.Int1 != ints[0] {
 					t.Errorf("field 1 should be %d, was %d", ints[0], out.Int1)
 				}
-				if (count == 4 || count == 3) && out.Int4 != 0 {
-					t.Errorf("expected field 4 to be zero")
-				} else if count == 3 && out.Int3 != 0 {
-					t.Errorf("expected field 3 to be zero")
+				switch count {
+				case 2:
+					if out.Int3 != 0 {
+						t.Errorf("expected field 3 to be zero, was %d", out.Int3)
+					}
+					fallthrough
+				case 3:
+					if out.Int4 != 0 {
+						t.Errorf("expected field 4 to be zero, was %d", out.Int4)
+					}
 				}
 				if err != nil {
 					t.Errorf("expected no error when unmarshaling, got: %s", err)

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -1,0 +1,57 @@
+package testing
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestOptionalFields(t *testing.T) {
+	ints := []int64{1, 2, 3, 4, 5}
+
+	objects := make([][]byte, 5)
+	for i := range objects {
+		count := i + 1
+		t.Run(fmt.Sprintf("length-%d", count), func(t *testing.T) {
+			var buf bytes.Buffer
+			obj := IntArray{Ints: ints[:count]}
+			if err := obj.MarshalCBOR(&buf); err != nil {
+				t.Fatal(err)
+			}
+
+			var out TupleWithOptionalFields
+			err := out.UnmarshalCBOR(&buf)
+			switch count {
+			case 4:
+				if out.Int4 != ints[3] {
+					t.Errorf("field 4 should be %d, was %d", ints[3], out.Int4)
+				}
+				fallthrough
+			case 3:
+				if out.Int3 != ints[2] {
+					t.Errorf("field 4 should be %d, was %d", ints[3], out.Int4)
+				}
+				fallthrough
+			case 2:
+				if out.Int2 != ints[1] {
+					t.Errorf("field 4 should be %d, was %d", ints[1], out.Int2)
+				}
+				if out.Int1 != ints[0] {
+					t.Errorf("field 4 should be %d, was %d", ints[0], out.Int1)
+				}
+				if err != nil {
+					t.Errorf("expected no error when unmarshaling, got: %s", err)
+				}
+			case 1, 0:
+				if err == nil {
+					t.Errorf("expected an error when unmarshaling with too few fields")
+				}
+			default:
+				if err == nil {
+					t.Errorf("expected an error when unmarshaling with too many fields")
+				}
+			}
+		})
+	}
+
+}

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -19,7 +19,14 @@ func TestOptionalFields(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var out TupleWithOptionalFields
+			// Pre-fill with garbage. We want optional fields to be reset to their
+			// defaults.
+			out := TupleWithOptionalFields{
+				Int1: 0xf1,
+				Int2: 0xf2,
+				Int3: 0xf3,
+				Int4: 0xf4,
+			}
 			err := out.UnmarshalCBOR(&buf)
 			switch count {
 			case 4:

--- a/testing/types.go
+++ b/testing/types.go
@@ -210,3 +210,10 @@ type StringPtrSlices struct {
 	Strings    []string
 	StringPtrs []*string
 }
+
+type TupleWithOptionalFields struct {
+	Int1 int64
+	Int2 int64
+	Int3 int64 `cborgen:"optional"`
+	Int4 int64 `cborgen:"optional"`
+}


### PR DESCRIPTION
Motivation: This makes it possible to add fields to structs while still being able to decode versions that don't include those fields.

Fields at the end of a tuple-encoded struct can be now marked as `cborgen:"optional"`. When thus marked:

1. These fields are not required when unmarshaling CBOR into this struct. Instead, they'll be initialized to their respective zero values.
2. These fields are still written out when marshaling into CBOR.

Marking map-encoded struct fields as optional is legal but has no impact in practice as all map fields are optional. As before, tuple-encoded structs will not omit "omitempty" fields, even when optional.