### PR TITLE
fix: block scope all variable reuses to fix trailing "optional" length check

### DIFF
--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -76,45 +76,48 @@ func (t *SignedArray) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Signed ([]uint64) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Signed: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Signed: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Signed = make([]uint64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Signed = make([]uint64, extra)
+		}
 
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				{
+
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					t.Signed[i] = uint64(extra)
+
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.Signed[i] = uint64(extra)
 
 			}
-
 		}
 	}
 	return nil
@@ -249,7 +252,7 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cr.ReadHeader()
+		maj, extra, err := cr.ReadHeader()
 		if err != nil {
 			return err
 		}
@@ -261,26 +264,29 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Binary ([]uint8) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 2097152 {
-		return fmt.Errorf("t.Binary: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 0 {
-		t.Binary = make([]uint8, extra)
-	}
+		if extra > 2097152 {
+			return fmt.Errorf("t.Binary: byte array too large (%d)", extra)
+		}
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("expected byte array")
+		}
 
-	if _, err := io.ReadFull(cr, t.Binary); err != nil {
-		return err
-	}
+		if extra > 0 {
+			t.Binary = make([]uint8, extra)
+		}
 
+		if _, err := io.ReadFull(cr, t.Binary); err != nil {
+			return err
+		}
+
+	}
 	// t.Signed (int64) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()
@@ -318,41 +324,44 @@ func (t *SimpleTypeOne) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Strings ([]string) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Strings: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Strings: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Strings = make([]string, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Strings = make([]string, extra)
+		}
 
+		for i := 0; i < int(extra); i++ {
 			{
-				sval, err := cbg.ReadStringWithMax(cr, 8192)
-				if err != nil {
-					return err
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+
+				{
+					sval, err := cbg.ReadStringWithMax(cr, 8192)
+					if err != nil {
+						return err
+					}
+
+					t.Strings[i] = string(sval)
 				}
 
-				t.Strings[i] = string(sval)
 			}
-
 		}
 	}
 	return nil
@@ -549,149 +558,162 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Others ([]uint64) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Others: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Others: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Others = make([]uint64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Others = make([]uint64, extra)
+		}
 
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				{
+
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					t.Others[i] = uint64(extra)
+
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.Others[i] = uint64(extra)
 
 			}
-
 		}
 	}
 	// t.SignedOthers ([]int64) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.SignedOthers: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.SignedOthers: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.SignedOthers = make([]int64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.SignedOthers = make([]int64, extra)
+		}
+
+		for i := 0; i < int(extra); i++ {
 			{
-				maj, extra, err := cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				var extraI int64
-				switch maj {
-				case cbg.MajUnsignedInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 positive overflow")
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+				{
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
 					}
-				case cbg.MajNegativeInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 negative overflow")
+					var extraI int64
+					switch maj {
+					case cbg.MajUnsignedInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 positive overflow")
+						}
+					case cbg.MajNegativeInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 negative overflow")
+						}
+						extraI = -1 - extraI
+					default:
+						return fmt.Errorf("wrong type for int64 field: %d", maj)
 					}
-					extraI = -1 - extraI
-				default:
-					return fmt.Errorf("wrong type for int64 field: %d", maj)
+
+					t.SignedOthers[i] = int64(extraI)
 				}
 
-				t.SignedOthers[i] = int64(extraI)
 			}
-
 		}
 	}
 	// t.Test ([][]uint8) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Test: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Test: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Test = make([][]uint8, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Test = make([][]uint8, extra)
+		}
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
+		for i := 0; i < int(extra); i++ {
+			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+
+				{
+
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+
+					if extra > 2097152 {
+						return fmt.Errorf("t.Test[i]: byte array too large (%d)", extra)
+					}
+					if maj != cbg.MajByteString {
+						return fmt.Errorf("expected byte array")
+					}
+
+					if extra > 0 {
+						t.Test[i] = make([]uint8, extra)
+					}
+
+					if _, err := io.ReadFull(cr, t.Test[i]); err != nil {
+						return err
+					}
+
+				}
+
 			}
-
-			if extra > 2097152 {
-				return fmt.Errorf("t.Test[i]: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
-
-			if extra > 0 {
-				t.Test[i] = make([]uint8, extra)
-			}
-
-			if _, err := io.ReadFull(cr, t.Test[i]); err != nil {
-				return err
-			}
-
 		}
 	}
 	// t.Dog (string) (string)
@@ -706,45 +728,48 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Numbers ([]testing.NamedNumber) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Numbers: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Numbers: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Numbers = make([]NamedNumber, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Numbers = make([]NamedNumber, extra)
+		}
 
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				{
+
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					t.Numbers[i] = NamedNumber(extra)
+
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.Numbers[i] = NamedNumber(extra)
 
 			}
-
 		}
 	}
 	// t.Pizza (uint64) (uint64)
@@ -759,7 +784,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cr.ReadHeader()
+			maj, extra, err := cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -783,7 +808,7 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cr.ReadHeader()
+			maj, extra, err := cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -797,38 +822,40 @@ func (t *SimpleTypeTwo) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Arrrrrghay ([3]testing.SimpleTypeOne) (array)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Arrrrrghay: array too large (%d)", extra)
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Arrrrrghay: array too large (%d)", extra)
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-	if extra != 3 {
-		return fmt.Errorf("expected array to have 3 elements")
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
+		if extra != 3 {
+			return fmt.Errorf("expected array to have 3 elements")
+		}
 
-	t.Arrrrrghay = [3]SimpleTypeOne{}
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
-
+		t.Arrrrrghay = [3]SimpleTypeOne{}
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				if err := t.Arrrrrghay[i].UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.Arrrrrghay[i]: %w", err)
+				{
+
+					if err := t.Arrrrrghay[i].UnmarshalCBOR(cr); err != nil {
+						return xerrors.Errorf("unmarshaling t.Arrrrrghay[i]: %w", err)
+					}
+
 				}
-
 			}
 		}
 	}
@@ -925,7 +952,7 @@ func (t *DeferredContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cr.ReadHeader()
+		maj, extra, err := cr.ReadHeader()
 		if err != nil {
 			return err
 		}
@@ -1021,85 +1048,91 @@ func (t *FixedArrays) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Bytes ([20]uint8) (array)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 2097152 {
-		return fmt.Errorf("t.Bytes: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
-	if extra != 20 {
-		return fmt.Errorf("expected array to have 20 elements")
-	}
+		if extra > 2097152 {
+			return fmt.Errorf("t.Bytes: byte array too large (%d)", extra)
+		}
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("expected byte array")
+		}
+		if extra != 20 {
+			return fmt.Errorf("expected array to have 20 elements")
+		}
 
-	t.Bytes = [20]uint8{}
-	if _, err := io.ReadFull(cr, t.Bytes[:]); err != nil {
-		return err
+		t.Bytes = [20]uint8{}
+		if _, err := io.ReadFull(cr, t.Bytes[:]); err != nil {
+			return err
+		}
 	}
 	// t.Uint8 ([20]uint8) (array)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 2097152 {
-		return fmt.Errorf("t.Uint8: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
-	if extra != 20 {
-		return fmt.Errorf("expected array to have 20 elements")
-	}
+		if extra > 2097152 {
+			return fmt.Errorf("t.Uint8: byte array too large (%d)", extra)
+		}
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("expected byte array")
+		}
+		if extra != 20 {
+			return fmt.Errorf("expected array to have 20 elements")
+		}
 
-	t.Uint8 = [20]uint8{}
-	if _, err := io.ReadFull(cr, t.Uint8[:]); err != nil {
-		return err
+		t.Uint8 = [20]uint8{}
+		if _, err := io.ReadFull(cr, t.Uint8[:]); err != nil {
+			return err
+		}
 	}
 	// t.Uint64 ([20]uint64) (array)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Uint64: array too large (%d)", extra)
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Uint64: array too large (%d)", extra)
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-	if extra != 20 {
-		return fmt.Errorf("expected array to have 20 elements")
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
+		if extra != 20 {
+			return fmt.Errorf("expected array to have 20 elements")
+		}
 
-	t.Uint64 = [20]uint64{}
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
-
+		t.Uint64 = [20]uint64{}
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.Uint64[i] = uint64(extra)
+				{
 
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					t.Uint64[i] = uint64(extra)
+
+				}
 			}
 		}
 	}
@@ -1276,26 +1309,29 @@ func (t *BigField) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.LargeBytes ([]uint8) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 10000000 {
-		return fmt.Errorf("t.LargeBytes: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 0 {
-		t.LargeBytes = make([]uint8, extra)
-	}
+		if extra > 10000000 {
+			return fmt.Errorf("t.LargeBytes: byte array too large (%d)", extra)
+		}
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("expected byte array")
+		}
 
-	if _, err := io.ReadFull(cr, t.LargeBytes); err != nil {
-		return err
-	}
+		if extra > 0 {
+			t.LargeBytes = make([]uint8, extra)
+		}
 
+		if _, err := io.ReadFull(cr, t.LargeBytes); err != nil {
+			return err
+		}
+
+	}
 	return nil
 }
 
@@ -1329,62 +1365,61 @@ func (t *IntArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArray{}
 
 	cr := cbg.NewCborReader(r)
-	var maj byte
-	var extra uint64
-	_ = maj
-	_ = extra
 	// t.Ints ([]int64) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Ints: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Ints: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Ints = make([]int64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Ints = make([]int64, extra)
+		}
+
+		for i := 0; i < int(extra); i++ {
 			{
-				maj, extra, err := cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				var extraI int64
-				switch maj {
-				case cbg.MajUnsignedInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 positive overflow")
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+				{
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
 					}
-				case cbg.MajNegativeInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 negative overflow")
+					var extraI int64
+					switch maj {
+					case cbg.MajUnsignedInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 positive overflow")
+						}
+					case cbg.MajNegativeInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 negative overflow")
+						}
+						extraI = -1 - extraI
+					default:
+						return fmt.Errorf("wrong type for int64 field: %d", maj)
 					}
-					extraI = -1 - extraI
-				default:
-					return fmt.Errorf("wrong type for int64 field: %d", maj)
+
+					t.Ints[i] = int64(extraI)
 				}
 
-				t.Ints[i] = int64(extraI)
 			}
-
 		}
 	}
 	return nil
@@ -1420,62 +1455,61 @@ func (t *IntAliasArray) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntAliasArray{}
 
 	cr := cbg.NewCborReader(r)
-	var maj byte
-	var extra uint64
-	_ = maj
-	_ = extra
 	// t.Ints ([]testing.IntAlias) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("t.Ints: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("t.Ints: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Ints = make([]IntAlias, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Ints = make([]IntAlias, extra)
+		}
+
+		for i := 0; i < int(extra); i++ {
 			{
-				maj, extra, err := cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				var extraI int64
-				switch maj {
-				case cbg.MajUnsignedInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 positive overflow")
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+				{
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
 					}
-				case cbg.MajNegativeInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 negative overflow")
+					var extraI int64
+					switch maj {
+					case cbg.MajUnsignedInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 positive overflow")
+						}
+					case cbg.MajNegativeInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 negative overflow")
+						}
+						extraI = -1 - extraI
+					default:
+						return fmt.Errorf("wrong type for int64 field: %d", maj)
 					}
-					extraI = -1 - extraI
-				default:
-					return fmt.Errorf("wrong type for int64 field: %d", maj)
+
+					t.Ints[i] = IntAlias(extraI)
 				}
 
-				t.Ints[i] = IntAlias(extraI)
 			}
-
 		}
 	}
 	return nil
@@ -1782,7 +1816,7 @@ func (t *TupleIntArrayOptionals) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		maj, extra, err = cr.ReadHeader()
+		maj, extra, err := cr.ReadHeader()
 		if err != nil {
 			return err
 		}
@@ -1804,7 +1838,7 @@ func (t *TupleIntArrayOptionals) UnmarshalCBOR(r io.Reader) (err error) {
 			if err := cr.UnreadByte(); err != nil {
 				return err
 			}
-			maj, extra, err = cr.ReadHeader()
+			maj, extra, err := cr.ReadHeader()
 			if err != nil {
 				return err
 			}
@@ -1849,62 +1883,61 @@ func (t *IntArrayNewType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArrayNewType{}
 
 	cr := cbg.NewCborReader(r)
-	var maj byte
-	var extra uint64
-	_ = maj
-	_ = extra
 	// (*t) (testing.IntArrayNewType) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("(*t): array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("(*t): array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		(*t) = make([]int64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			(*t) = make([]int64, extra)
+		}
+
+		for i := 0; i < int(extra); i++ {
 			{
-				maj, extra, err := cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				var extraI int64
-				switch maj {
-				case cbg.MajUnsignedInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 positive overflow")
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+				{
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
 					}
-				case cbg.MajNegativeInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 negative overflow")
+					var extraI int64
+					switch maj {
+					case cbg.MajUnsignedInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 positive overflow")
+						}
+					case cbg.MajNegativeInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 negative overflow")
+						}
+						extraI = -1 - extraI
+					default:
+						return fmt.Errorf("wrong type for int64 field: %d", maj)
 					}
-					extraI = -1 - extraI
-				default:
-					return fmt.Errorf("wrong type for int64 field: %d", maj)
+
+					(*t)[i] = int64(extraI)
 				}
 
-				(*t)[i] = int64(extraI)
 			}
-
 		}
 	}
 	return nil
@@ -1940,62 +1973,61 @@ func (t *IntArrayAliasNewType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = IntArrayAliasNewType{}
 
 	cr := cbg.NewCborReader(r)
-	var maj byte
-	var extra uint64
-	_ = maj
-	_ = extra
 	// (*t) (testing.IntArrayAliasNewType) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 8192 {
-		return fmt.Errorf("(*t): array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 8192 {
+			return fmt.Errorf("(*t): array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		(*t) = make([]IntAlias, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			(*t) = make([]IntAlias, extra)
+		}
+
+		for i := 0; i < int(extra); i++ {
 			{
-				maj, extra, err := cr.ReadHeader()
-				if err != nil {
-					return err
-				}
-				var extraI int64
-				switch maj {
-				case cbg.MajUnsignedInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 positive overflow")
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
+				{
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
 					}
-				case cbg.MajNegativeInt:
-					extraI = int64(extra)
-					if extraI < 0 {
-						return fmt.Errorf("int64 negative overflow")
+					var extraI int64
+					switch maj {
+					case cbg.MajUnsignedInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 positive overflow")
+						}
+					case cbg.MajNegativeInt:
+						extraI = int64(extra)
+						if extraI < 0 {
+							return fmt.Errorf("int64 negative overflow")
+						}
+						extraI = -1 - extraI
+					default:
+						return fmt.Errorf("wrong type for int64 field: %d", maj)
 					}
-					extraI = -1 - extraI
-				default:
-					return fmt.Errorf("wrong type for int64 field: %d", maj)
+
+					(*t)[i] = IntAlias(extraI)
 				}
 
-				(*t)[i] = IntAlias(extraI)
 			}
-
 		}
 	}
 	return nil
@@ -2053,51 +2085,49 @@ func (t *MapTransparentType) UnmarshalCBOR(r io.Reader) (err error) {
 	*t = MapTransparentType{}
 
 	cr := cbg.NewCborReader(r)
-	var maj byte
-	var extra uint64
-	_ = maj
-	_ = extra
 	// (*t) (testing.MapTransparentType) (map)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajMap {
-		return fmt.Errorf("expected a map (major type 5)")
-	}
-	if extra > 4096 {
-		return fmt.Errorf("(*t): map too large")
-	}
-
-	(*t) = make(map[string]string, extra)
-
-	for i, l := 0, int(extra); i < l; i++ {
-
-		var k string
-
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
-			}
-
-			k = string(sval)
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajMap {
+			return fmt.Errorf("expected a map (major type 5)")
+		}
+		if extra > 4096 {
+			return fmt.Errorf("(*t): map too large")
 		}
 
-		var v string
+		(*t) = make(map[string]string, extra)
 
-		{
-			sval, err := cbg.ReadStringWithMax(cr, 8192)
-			if err != nil {
-				return err
+		for i, l := 0, int(extra); i < l; i++ {
+
+			var k string
+
+			{
+				sval, err := cbg.ReadStringWithMax(cr, 8192)
+				if err != nil {
+					return err
+				}
+
+				k = string(sval)
 			}
 
-			v = string(sval)
+			var v string
+
+			{
+				sval, err := cbg.ReadStringWithMax(cr, 8192)
+				if err != nil {
+					return err
+				}
+
+				v = string(sval)
+			}
+
+			(*t)[k] = v
+
 		}
-
-		(*t)[k] = v
-
 	}
 	return nil
 }
@@ -2164,36 +2194,38 @@ func (t *BigIntContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Int (big.Int) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if maj != cbg.MajTag || extra != 2 {
-		return fmt.Errorf("big ints should be cbor bignums")
-	}
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("big ints should be tagged cbor byte strings")
-	}
-
-	if extra > 256 {
-		return fmt.Errorf("t.Int: cbor bignum was too large")
-	}
-
-	if extra > 0 {
-		buf := make([]byte, extra)
-		if _, err := io.ReadFull(cr, buf); err != nil {
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
 			return err
 		}
-		t.Int = big.NewInt(0).SetBytes(buf)
-	} else {
-		t.Int = big.NewInt(0)
+
+		if maj != cbg.MajTag || extra != 2 {
+			return fmt.Errorf("big ints should be cbor bignums")
+		}
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("big ints should be tagged cbor byte strings")
+		}
+
+		if extra > 256 {
+			return fmt.Errorf("t.Int: cbor bignum was too large")
+		}
+
+		if extra > 0 {
+			buf := make([]byte, extra)
+			if _, err := io.ReadFull(cr, buf); err != nil {
+				return err
+			}
+			t.Int = big.NewInt(0).SetBytes(buf)
+		} else {
+			t.Int = big.NewInt(0)
+		}
 	}
 	return nil
 }
@@ -2223,15 +2255,10 @@ func (t *TupleWithOptionalFields) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Int2 (int64) (int64)
-	if t.Int2 >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Int2)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Int2-1)); err != nil {
-			return err
-		}
+	// t.Uint2 (uint64) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Uint2)); err != nil {
+		return err
 	}
 
 	// t.Int3 (int64) (int64)
@@ -2311,30 +2338,19 @@ func (t *TupleWithOptionalFields) UnmarshalCBOR(r io.Reader) (err error) {
 
 		t.Int1 = int64(extraI)
 	}
-	// t.Int2 (int64) (int64)
+	// t.Uint2 (uint64) (uint64)
+
 	{
+
 		maj, extra, err := cr.ReadHeader()
 		if err != nil {
 			return err
 		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
 		}
+		t.Uint2 = uint64(extra)
 
-		t.Int2 = int64(extraI)
 	}
 	// t.Int3 (int64) (int64)
 	if extra < 3 {

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -299,52 +299,59 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Test ([][]uint8) (slice)
 		case "Test":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.Test: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.Test: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.Test = make([][]uint8, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.Test = make([][]uint8, extra)
+				}
 
-					maj, extra, err = cr.ReadHeader()
-					if err != nil {
-						return err
+				for i := 0; i < int(extra); i++ {
+					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
+
+						{
+
+							maj, extra, err := cr.ReadHeader()
+							if err != nil {
+								return err
+							}
+
+							if extra > 2097152 {
+								return fmt.Errorf("t.Test[i]: byte array too large (%d)", extra)
+							}
+							if maj != cbg.MajByteString {
+								return fmt.Errorf("expected byte array")
+							}
+
+							if extra > 0 {
+								t.Test[i] = make([]uint8, extra)
+							}
+
+							if _, err := io.ReadFull(cr, t.Test[i]); err != nil {
+								return err
+							}
+
+						}
+
 					}
-
-					if extra > 2097152 {
-						return fmt.Errorf("t.Test[i]: byte array too large (%d)", extra)
-					}
-					if maj != cbg.MajByteString {
-						return fmt.Errorf("expected byte array")
-					}
-
-					if extra > 0 {
-						t.Test[i] = make([]uint8, extra)
-					}
-
-					if _, err := io.ReadFull(cr, t.Test[i]); err != nil {
-						return err
-					}
-
 				}
 			}
 			// t.Stuff (testing.SimpleTypeTree) (struct)
@@ -370,45 +377,48 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Others ([]uint64) (slice)
 		case "Others":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.Others: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.Others: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.Others = make([]uint64, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.Others = make([]uint64, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						maj, extra, err = cr.ReadHeader()
-						if err != nil {
-							return err
+						{
+
+							maj, extra, err := cr.ReadHeader()
+							if err != nil {
+								return err
+							}
+							if maj != cbg.MajUnsignedInt {
+								return fmt.Errorf("wrong type for uint64 field")
+							}
+							t.Others[i] = uint64(extra)
+
 						}
-						if maj != cbg.MajUnsignedInt {
-							return fmt.Errorf("wrong type for uint64 field")
-						}
-						t.Others[i] = uint64(extra)
 
 					}
-
 				}
 			}
 			// t.Stufff (testing.SimpleTypeTwo) (struct)
@@ -444,7 +454,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 						return err
 					}
 
-					maj, extra, err = cr.ReadHeader()
+					maj, extra, err := cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -477,7 +487,7 @@ func (t *SimpleTypeTree) UnmarshalCBOR(r io.Reader) (err error) {
 					if err := cr.UnreadByte(); err != nil {
 						return err
 					}
-					maj, extra, err = cr.ReadHeader()
+					maj, extra, err := cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -621,20 +631,22 @@ func (t *NeedScratchForMap) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Thing (bool) (bool)
 		case "Thing":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-			if maj != cbg.MajOther {
-				return fmt.Errorf("booleans must be major type 7")
-			}
-			switch extra {
-			case 20:
-				t.Thing = false
-			case 21:
-				t.Thing = true
-			default:
-				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajOther {
+					return fmt.Errorf("booleans must be major type 7")
+				}
+				switch extra {
+				case 20:
+					t.Thing = false
+				case 21:
+					t.Thing = true
+				default:
+					return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+				}
 			}
 
 		default:
@@ -939,51 +951,53 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-			if maj != cbg.MajMap {
-				return fmt.Errorf("expected a map (major type 5)")
-			}
-			if extra > 4096 {
-				return fmt.Errorf("t.OldMap: map too large")
-			}
-
-			t.OldMap = make(map[string]SimpleTypeOne, extra)
-
-			for i, l := 0, int(extra); i < l; i++ {
-
-				var k string
-
-				{
-					sval, err := cbg.ReadStringWithMax(cr, 8192)
-					if err != nil {
-						return err
-					}
-
-					k = string(sval)
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajMap {
+					return fmt.Errorf("expected a map (major type 5)")
+				}
+				if extra > 4096 {
+					return fmt.Errorf("t.OldMap: map too large")
 				}
 
-				var v SimpleTypeOne
+				t.OldMap = make(map[string]SimpleTypeOne, extra)
 
-				{
+				for i, l := 0, int(extra); i < l; i++ {
 
-					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+					var k string
+
+					{
+						sval, err := cbg.ReadStringWithMax(cr, 8192)
+						if err != nil {
+							return err
+						}
+
+						k = string(sval)
 					}
 
+					var v SimpleTypeOne
+
+					{
+
+						if err := v.UnmarshalCBOR(cr); err != nil {
+							return xerrors.Errorf("unmarshaling v: %w", err)
+						}
+
+					}
+
+					t.OldMap[k] = v
+
 				}
-
-				t.OldMap[k] = v
-
 			}
 			// t.OldNum (uint64) (uint64)
 		case "OldNum":
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
+				maj, extra, err := cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -1030,65 +1044,71 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.OldArray: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.OldArray: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.OldArray = make([]SimpleTypeOne, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.OldArray = make([]SimpleTypeOne, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+						{
+
+							if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
+								return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+							}
+
 						}
 
 					}
-
 				}
 			}
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 2097152 {
-				return fmt.Errorf("t.OldBytes: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if extra > 0 {
-				t.OldBytes = make([]uint8, extra)
-			}
+				if extra > 2097152 {
+					return fmt.Errorf("t.OldBytes: byte array too large (%d)", extra)
+				}
+				if maj != cbg.MajByteString {
+					return fmt.Errorf("expected byte array")
+				}
 
-			if _, err := io.ReadFull(cr, t.OldBytes); err != nil {
-				return err
-			}
+				if extra > 0 {
+					t.OldBytes = make([]uint8, extra)
+				}
 
+				if _, err := io.ReadFull(cr, t.OldBytes); err != nil {
+					return err
+				}
+
+			}
 			// t.OldStruct (testing.SimpleTypeOne) (struct)
 		case "OldStruct":
 
@@ -1102,95 +1122,101 @@ func (t *SimpleStructV1) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldCidArray ([]cid.Cid) (slice)
 		case "OldCidArray":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.OldCidArray: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.OldCidArray: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.OldCidArray = make([]cid.Cid, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.OldCidArray = make([]cid.Cid, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						c, err := cbg.ReadCid(cr)
-						if err != nil {
-							return xerrors.Errorf("failed to read cid field t.OldCidArray[i]: %w", err)
+						{
+
+							c, err := cbg.ReadCid(cr)
+							if err != nil {
+								return xerrors.Errorf("failed to read cid field t.OldCidArray[i]: %w", err)
+							}
+
+							t.OldCidArray[i] = c
+
 						}
 
-						t.OldCidArray[i] = c
-
 					}
-
 				}
 			}
 			// t.OldCidPtrArray ([]*cid.Cid) (slice)
 		case "OldCidPtrArray":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.OldCidPtrArray: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.OldCidPtrArray: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.OldCidPtrArray = make([]*cid.Cid, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.OldCidPtrArray = make([]*cid.Cid, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						b, err := cr.ReadByte()
-						if err != nil {
-							return err
-						}
-						if b != cbg.CborNull[0] {
-							if err := cr.UnreadByte(); err != nil {
+						{
+
+							b, err := cr.ReadByte()
+							if err != nil {
 								return err
 							}
+							if b != cbg.CborNull[0] {
+								if err := cr.UnreadByte(); err != nil {
+									return err
+								}
 
-							c, err := cbg.ReadCid(cr)
-							if err != nil {
-								return xerrors.Errorf("failed to read cid field t.OldCidPtrArray[i]: %w", err)
+								c, err := cbg.ReadCid(cr)
+								if err != nil {
+									return xerrors.Errorf("failed to read cid field t.OldCidPtrArray[i]: %w", err)
+								}
+
+								t.OldCidPtrArray[i] = &c
 							}
 
-							t.OldCidPtrArray[i] = &c
 						}
 
 					}
-
 				}
 			}
 
@@ -1610,51 +1636,53 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.NewMap (map[string]testing.SimpleTypeOne) (map)
 		case "NewMap":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-			if maj != cbg.MajMap {
-				return fmt.Errorf("expected a map (major type 5)")
-			}
-			if extra > 4096 {
-				return fmt.Errorf("t.NewMap: map too large")
-			}
-
-			t.NewMap = make(map[string]SimpleTypeOne, extra)
-
-			for i, l := 0, int(extra); i < l; i++ {
-
-				var k string
-
-				{
-					sval, err := cbg.ReadStringWithMax(cr, 8192)
-					if err != nil {
-						return err
-					}
-
-					k = string(sval)
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajMap {
+					return fmt.Errorf("expected a map (major type 5)")
+				}
+				if extra > 4096 {
+					return fmt.Errorf("t.NewMap: map too large")
 				}
 
-				var v SimpleTypeOne
+				t.NewMap = make(map[string]SimpleTypeOne, extra)
 
-				{
+				for i, l := 0, int(extra); i < l; i++ {
 
-					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+					var k string
+
+					{
+						sval, err := cbg.ReadStringWithMax(cr, 8192)
+						if err != nil {
+							return err
+						}
+
+						k = string(sval)
 					}
 
+					var v SimpleTypeOne
+
+					{
+
+						if err := v.UnmarshalCBOR(cr); err != nil {
+							return xerrors.Errorf("unmarshaling v: %w", err)
+						}
+
+					}
+
+					t.NewMap[k] = v
+
 				}
-
-				t.NewMap[k] = v
-
 			}
 			// t.NewNum (uint64) (uint64)
 		case "NewNum":
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
+				maj, extra, err := cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -1701,51 +1729,53 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.OldMap (map[string]testing.SimpleTypeOne) (map)
 		case "OldMap":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-			if maj != cbg.MajMap {
-				return fmt.Errorf("expected a map (major type 5)")
-			}
-			if extra > 4096 {
-				return fmt.Errorf("t.OldMap: map too large")
-			}
-
-			t.OldMap = make(map[string]SimpleTypeOne, extra)
-
-			for i, l := 0, int(extra); i < l; i++ {
-
-				var k string
-
-				{
-					sval, err := cbg.ReadStringWithMax(cr, 8192)
-					if err != nil {
-						return err
-					}
-
-					k = string(sval)
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajMap {
+					return fmt.Errorf("expected a map (major type 5)")
+				}
+				if extra > 4096 {
+					return fmt.Errorf("t.OldMap: map too large")
 				}
 
-				var v SimpleTypeOne
+				t.OldMap = make(map[string]SimpleTypeOne, extra)
 
-				{
+				for i, l := 0, int(extra); i < l; i++ {
 
-					if err := v.UnmarshalCBOR(cr); err != nil {
-						return xerrors.Errorf("unmarshaling v: %w", err)
+					var k string
+
+					{
+						sval, err := cbg.ReadStringWithMax(cr, 8192)
+						if err != nil {
+							return err
+						}
+
+						k = string(sval)
 					}
 
+					var v SimpleTypeOne
+
+					{
+
+						if err := v.UnmarshalCBOR(cr); err != nil {
+							return xerrors.Errorf("unmarshaling v: %w", err)
+						}
+
+					}
+
+					t.OldMap[k] = v
+
 				}
-
-				t.OldMap[k] = v
-
 			}
 			// t.OldNum (uint64) (uint64)
 		case "OldNum":
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
+				maj, extra, err := cr.ReadHeader()
 				if err != nil {
 					return err
 				}
@@ -1792,127 +1822,139 @@ func (t *SimpleStructV2) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.NewArray ([]testing.SimpleTypeOne) (slice)
 		case "NewArray":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.NewArray: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.NewArray: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.NewArray = make([]SimpleTypeOne, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.NewArray = make([]SimpleTypeOne, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						if err := t.NewArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.NewArray[i]: %w", err)
+						{
+
+							if err := t.NewArray[i].UnmarshalCBOR(cr); err != nil {
+								return xerrors.Errorf("unmarshaling t.NewArray[i]: %w", err)
+							}
+
 						}
 
 					}
-
 				}
 			}
 			// t.NewBytes ([]uint8) (slice)
 		case "NewBytes":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 2097152 {
-				return fmt.Errorf("t.NewBytes: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if extra > 0 {
-				t.NewBytes = make([]uint8, extra)
-			}
+				if extra > 2097152 {
+					return fmt.Errorf("t.NewBytes: byte array too large (%d)", extra)
+				}
+				if maj != cbg.MajByteString {
+					return fmt.Errorf("expected byte array")
+				}
 
-			if _, err := io.ReadFull(cr, t.NewBytes); err != nil {
-				return err
-			}
+				if extra > 0 {
+					t.NewBytes = make([]uint8, extra)
+				}
 
+				if _, err := io.ReadFull(cr, t.NewBytes); err != nil {
+					return err
+				}
+
+			}
 			// t.OldArray ([]testing.SimpleTypeOne) (slice)
 		case "OldArray":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.OldArray: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.OldArray: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.OldArray = make([]SimpleTypeOne, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.OldArray = make([]SimpleTypeOne, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
-							return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+						{
+
+							if err := t.OldArray[i].UnmarshalCBOR(cr); err != nil {
+								return xerrors.Errorf("unmarshaling t.OldArray[i]: %w", err)
+							}
+
 						}
 
 					}
-
 				}
 			}
 			// t.OldBytes ([]uint8) (slice)
 		case "OldBytes":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 2097152 {
-				return fmt.Errorf("t.OldBytes: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if extra > 0 {
-				t.OldBytes = make([]uint8, extra)
-			}
+				if extra > 2097152 {
+					return fmt.Errorf("t.OldBytes: byte array too large (%d)", extra)
+				}
+				if maj != cbg.MajByteString {
+					return fmt.Errorf("expected byte array")
+				}
 
-			if _, err := io.ReadFull(cr, t.OldBytes); err != nil {
-				return err
-			}
+				if extra > 0 {
+					t.OldBytes = make([]uint8, extra)
+				}
 
+				if _, err := io.ReadFull(cr, t.OldBytes); err != nil {
+					return err
+				}
+
+			}
 			// t.NewStruct (testing.SimpleTypeOne) (struct)
 		case "NewStruct":
 
@@ -2793,45 +2835,47 @@ func (t *MapStringString) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Snorkleblump (map[string]string) (map)
 		case "Snorkleblump":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-			if maj != cbg.MajMap {
-				return fmt.Errorf("expected a map (major type 5)")
-			}
-			if extra > 4096 {
-				return fmt.Errorf("t.Snorkleblump: map too large")
-			}
-
-			t.Snorkleblump = make(map[string]string, extra)
-
-			for i, l := 0, int(extra); i < l; i++ {
-
-				var k string
-
-				{
-					sval, err := cbg.ReadStringWithMax(cr, 8192)
-					if err != nil {
-						return err
-					}
-
-					k = string(sval)
+			{
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajMap {
+					return fmt.Errorf("expected a map (major type 5)")
+				}
+				if extra > 4096 {
+					return fmt.Errorf("t.Snorkleblump: map too large")
 				}
 
-				var v string
+				t.Snorkleblump = make(map[string]string, extra)
 
-				{
-					sval, err := cbg.ReadStringWithMax(cr, 8192)
-					if err != nil {
-						return err
+				for i, l := 0, int(extra); i < l; i++ {
+
+					var k string
+
+					{
+						sval, err := cbg.ReadStringWithMax(cr, 8192)
+						if err != nil {
+							return err
+						}
+
+						k = string(sval)
 					}
 
-					v = string(sval)
+					var v string
+
+					{
+						sval, err := cbg.ReadStringWithMax(cr, 8192)
+						if err != nil {
+							return err
+						}
+
+						v = string(sval)
+					}
+
+					t.Snorkleblump[k] = v
+
 				}
-
-				t.Snorkleblump[k] = v
-
 			}
 
 		default:
@@ -3080,6 +3124,7 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 		case "Not":
 
 			{
+
 				b, err := cr.ReadByte()
 				if err != nil {
 					return err
@@ -3089,7 +3134,7 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 						return err
 					}
 
-					maj, extra, err = cr.ReadHeader()
+					maj, extra, err := cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -3115,7 +3160,7 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 
 							{
 
-								maj, extra, err = cr.ReadHeader()
+								maj, extra, err := cr.ReadHeader()
 								if err != nil {
 									return err
 								}
@@ -3127,8 +3172,8 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 							}
 
 						}
-					}
 
+					}
 				}
 			}
 			// t.Beep (int64) (int64)
@@ -3160,74 +3205,81 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 			// t.Other ([]uint8) (slice)
 		case "Other":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 2097152 {
-				return fmt.Errorf("t.Other: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if extra > 0 {
-				t.Other = make([]uint8, extra)
-			}
+				if extra > 2097152 {
+					return fmt.Errorf("t.Other: byte array too large (%d)", extra)
+				}
+				if maj != cbg.MajByteString {
+					return fmt.Errorf("expected byte array")
+				}
 
-			if _, err := io.ReadFull(cr, t.Other); err != nil {
-				return err
-			}
+				if extra > 0 {
+					t.Other = make([]uint8, extra)
+				}
 
+				if _, err := io.ReadFull(cr, t.Other); err != nil {
+					return err
+				}
+
+			}
 			// t.Stuff ([]uint64) (slice)
 		case "Stuff":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.Stuff: array too large (%d)", extra)
-			}
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.Stuff: array too large (%d)", extra)
+				}
 
-			if extra > 0 {
-				t.Stuff = make([]uint64, extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
+				if extra > 0 {
+					t.Stuff = make([]uint64, extra)
+				}
 
+				for i := 0; i < int(extra); i++ {
 					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
-						maj, extra, err = cr.ReadHeader()
-						if err != nil {
-							return err
+						{
+
+							maj, extra, err := cr.ReadHeader()
+							if err != nil {
+								return err
+							}
+							if maj != cbg.MajUnsignedInt {
+								return fmt.Errorf("wrong type for uint64 field")
+							}
+							t.Stuff[i] = uint64(extra)
+
 						}
-						if maj != cbg.MajUnsignedInt {
-							return fmt.Errorf("wrong type for uint64 field")
-						}
-						t.Stuff[i] = uint64(extra)
 
 					}
-
 				}
 			}
 			// t.NotOther ([]uint8) (slice)
 		case "NotOther":
 
 			{
+
 				b, err := cr.ReadByte()
 				if err != nil {
 					return err
@@ -3237,7 +3289,7 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 						return err
 					}
 
-					maj, extra, err = cr.ReadHeader()
+					maj, extra, err := cr.ReadHeader()
 					if err != nil {
 						return err
 					}
@@ -3256,6 +3308,7 @@ func (t *TestSliceNilPreserve) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 
 				}
+
 			}
 
 		default:
@@ -3398,91 +3451,97 @@ func (t *StringPtrSlices) UnmarshalCBOR(r io.Reader) (err error) {
 		// t.Strings ([]string) (slice)
 		case "Strings":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+			{
 
-			if extra > 8192 {
-				return fmt.Errorf("t.Strings: array too large (%d)", extra)
-			}
-
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
-
-			if extra > 0 {
-				t.Strings = make([]string, extra)
-			}
-
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
-
-					{
-						sval, err := cbg.ReadStringWithMax(cr, 8192)
-						if err != nil {
-							return err
-						}
-
-						t.Strings[i] = string(sval)
-					}
-
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
 				}
-			}
-			// t.StringPtrs ([]*string) (slice)
-		case "StringPtrs":
 
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
+				if extra > 8192 {
+					return fmt.Errorf("t.Strings: array too large (%d)", extra)
+				}
 
-			if extra > 8192 {
-				return fmt.Errorf("t.StringPtrs: array too large (%d)", extra)
-			}
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
 
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
+				if extra > 0 {
+					t.Strings = make([]string, extra)
+				}
 
-			if extra > 0 {
-				t.StringPtrs = make([]*string, extra)
-			}
-
-			for i := 0; i < int(extra); i++ {
-				{
-					var maj byte
-					var extra uint64
-					var err error
-					_ = maj
-					_ = extra
-					_ = err
-
+				for i := 0; i < int(extra); i++ {
 					{
-						b, err := cr.ReadByte()
-						if err != nil {
-							return err
-						}
-						if b != cbg.CborNull[0] {
-							if err := cr.UnreadByte(); err != nil {
-								return err
-							}
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
 
+						{
 							sval, err := cbg.ReadStringWithMax(cr, 8192)
 							if err != nil {
 								return err
 							}
 
-							t.StringPtrs[i] = (*string)(&sval)
+							t.Strings[i] = string(sval)
 						}
-					}
 
+					}
+				}
+			}
+			// t.StringPtrs ([]*string) (slice)
+		case "StringPtrs":
+
+			{
+
+				maj, extra, err := cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+
+				if extra > 8192 {
+					return fmt.Errorf("t.StringPtrs: array too large (%d)", extra)
+				}
+
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
+
+				if extra > 0 {
+					t.StringPtrs = make([]*string, extra)
+				}
+
+				for i := 0; i < int(extra); i++ {
+					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
+
+						{
+							b, err := cr.ReadByte()
+							if err != nil {
+								return err
+							}
+							if b != cbg.CborNull[0] {
+								if err := cr.UnreadByte(); err != nil {
+									return err
+								}
+
+								sval, err := cbg.ReadStringWithMax(cr, 8192)
+								if err != nil {
+									return err
+								}
+
+								t.StringPtrs[i] = (*string)(&sval)
+							}
+						}
+
+					}
 				}
 			}
 

--- a/testing/cbor_options_gen.go
+++ b/testing/cbor_options_gen.go
@@ -100,69 +100,75 @@ func (t *LimitedStruct) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Arr ([]uint64) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 10 {
-		return fmt.Errorf("t.Arr: array too large (%d)", extra)
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+		if extra > 10 {
+			return fmt.Errorf("t.Arr: array too large (%d)", extra)
+		}
 
-	if extra > 0 {
-		t.Arr = make([]uint64, extra)
-	}
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected cbor array")
+		}
 
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
+		if extra > 0 {
+			t.Arr = make([]uint64, extra)
+		}
 
+		for i := 0; i < int(extra); i++ {
 			{
+				var maj byte
+				var extra uint64
+				var err error
+				_ = maj
+				_ = extra
+				_ = err
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				{
+
+					maj, extra, err := cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					t.Arr[i] = uint64(extra)
+
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.Arr[i] = uint64(extra)
 
 			}
-
 		}
 	}
 	// t.Byts ([]uint8) (slice)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 9 {
-		return fmt.Errorf("t.Byts: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
 
-	if extra > 0 {
-		t.Byts = make([]uint8, extra)
-	}
+		if extra > 9 {
+			return fmt.Errorf("t.Byts: byte array too large (%d)", extra)
+		}
+		if maj != cbg.MajByteString {
+			return fmt.Errorf("expected byte array")
+		}
 
-	if _, err := io.ReadFull(cr, t.Byts); err != nil {
-		return err
-	}
+		if extra > 0 {
+			t.Byts = make([]uint8, extra)
+		}
 
+		if _, err := io.ReadFull(cr, t.Byts); err != nil {
+			return err
+		}
+
+	}
 	// t.Str (string) (string)
 
 	{

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -22,10 +22,10 @@ func TestOptionalFields(t *testing.T) {
 			// Pre-fill with garbage. We want optional fields to be reset to their
 			// defaults.
 			out := TupleWithOptionalFields{
-				Int1: 0xf1,
-				Int2: 0xf2,
-				Int3: 0xf3,
-				Int4: 0xf4,
+				Int1:  0xf1,
+				Uint2: 0xf2,
+				Int3:  0xf3,
+				Int4:  0xf4,
 			}
 			err := out.UnmarshalCBOR(&buf)
 			switch count {
@@ -40,8 +40,8 @@ func TestOptionalFields(t *testing.T) {
 				}
 				fallthrough
 			case 2:
-				if out.Int2 != ints[1] {
-					t.Errorf("field 2 should be %d, was %d", ints[1], out.Int2)
+				if out.Uint2 != uint64(ints[1]) {
+					t.Errorf("field 2 should be %d, was %d", ints[1], out.Uint2)
 				}
 				if out.Int1 != ints[0] {
 					t.Errorf("field 1 should be %d, was %d", ints[0], out.Int1)

--- a/testing/types.go
+++ b/testing/types.go
@@ -212,8 +212,8 @@ type StringPtrSlices struct {
 }
 
 type TupleWithOptionalFields struct {
-	Int1 int64
-	Int2 int64
-	Int3 int64 `cborgen:"optional"`
-	Int4 int64 `cborgen:"optional"`
+	Int1  int64
+	Uint2 uint64
+	Int3  int64 `cborgen:"optional"`
+	Int4  int64 `cborgen:"optional"`
 }


### PR DESCRIPTION
A bug in https://github.com/whyrusleeping/cbor-gen/pull/109; many of the unmarshal components just reuse the primary `maj, extra, err` variables for `cr.ReadHeader()`, so that when you get to the end and want to use `extra` to length-check, it's already been overwritten with something else. This doesn't show up in the current tests because `int64` happens to block scope and create new variables. But uint64 doesn't, so that's included in the test now and it fails without the fix. I remember hitting this when I was doing the generics work too.

This is the "hard way" (proper way) of fixing it and makes a lot of churn in generated output.

https://github.com/whyrusleeping/cbor-gen/pull/112 is the easy way of fixing it.

 We can debate and pick one.