### PR TITLE
fix: capture field count early for "optional" length check

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1623,6 +1623,8 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 	if extra < {{ .MandatoryFieldCount }} {
 		return fmt.Errorf("cbor input has too few fields %d < {{ .MandatoryFieldCount }}", extra)
 	}
+	
+	fieldCount := extra
 {{ end }}
 
 `)
@@ -1641,7 +1643,7 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 		fmt.Fprintf(w, "\t// %s (%s) (%s)\n", f.Name, f.Type, f.Type.Kind())
 
 		if f.Optional {
-			fmt.Fprintf(w, "\tif extra < %d {\n\t\treturn nil\n\t}\n", fieldIndex+1)
+			fmt.Fprintf(w, "\tif fieldCount < %d {\n\t\treturn nil\n\t}\n", fieldIndex+1)
 		}
 
 		switch f.Type.Kind() {

--- a/testing/optional_test.go
+++ b/testing/optional_test.go
@@ -22,10 +22,10 @@ func TestOptionalFields(t *testing.T) {
 			// Pre-fill with garbage. We want optional fields to be reset to their
 			// defaults.
 			out := TupleWithOptionalFields{
-				Int1: 0xf1,
-				Int2: 0xf2,
-				Int3: 0xf3,
-				Int4: 0xf4,
+				Int1:  0xf1,
+				Uint2: 0xf2,
+				Int3:  0xf3,
+				Int4:  0xf4,
 			}
 			err := out.UnmarshalCBOR(&buf)
 			switch count {
@@ -40,8 +40,8 @@ func TestOptionalFields(t *testing.T) {
 				}
 				fallthrough
 			case 2:
-				if out.Int2 != ints[1] {
-					t.Errorf("field 2 should be %d, was %d", ints[1], out.Int2)
+				if out.Uint2 != uint64(ints[1]) {
+					t.Errorf("field 2 should be %d, was %d", ints[1], out.Uint2)
 				}
 				if out.Int1 != ints[0] {
 					t.Errorf("field 1 should be %d, was %d", ints[0], out.Int1)

--- a/testing/types.go
+++ b/testing/types.go
@@ -212,8 +212,8 @@ type StringPtrSlices struct {
 }
 
 type TupleWithOptionalFields struct {
-	Int1 int64
-	Int2 int64
-	Int3 int64 `cborgen:"optional"`
-	Int4 int64 `cborgen:"optional"`
+	Int1  int64
+	Uint2 uint64
+	Int3  int64 `cborgen:"optional"`
+	Int4  int64 `cborgen:"optional"`
 }


### PR DESCRIPTION
A bug in https://github.com/whyrusleeping/cbor-gen/pull/109; many of the unmarshal components just reuse the primary `maj, extra, err` variables for `cr.ReadHeader()`, so that when you get to the end and want to use `extra` to length-check, it's already been overwritten with something else. This doesn't show up in the current tests because `int64` happens to block scope and create new variables. But uint64 doesn't, so that's included in the test now and it fails without the fix. I remember hitting this when I was doing the generics work too.

This is the easy and less painful way of fixing it. Just capture the length and we're done.

https://github.com/whyrusleeping/cbor-gen/pull/111 is the "hard way" (proper way).

 We can debate and pick one.