### PR TITLE
Support maps of slices

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -635,6 +635,10 @@ func (g Gen) emitCborMarshalMapField(w io.Writer, f Field) error {
 		if err := g.emitCborMarshalStringField(w, Field{Name: "v"}); err != nil {
 			return err
 		}
+	case reflect.Slice:
+		if err := g.emitCborMarshalSliceField(w, Field{Name: "v", Type: f.Type.Elem(), Pkg: f.Pkg}); err != nil {
+			return err
+		}
 	case reflect.Ptr:
 		if f.Type.Elem().Elem().Kind() != reflect.Struct {
 			return fmt.Errorf("unsupported map elem ptr type: %s", f.Type.Elem())
@@ -1229,6 +1233,22 @@ func (g Gen) emitCborUnmarshalMapField(w io.Writer, f Field) error {
 `); err != nil {
 			return err
 		}
+	case reflect.Slice:
+		subf := Field{Name: "v", Type: t, Pkg: f.Pkg}
+		if err := g.doTemplate(w, subf, `
+	var v {{ .TypeName }}
+`); err != nil {
+			return err
+		}
+		if err := g.emitCborUnmarshalSliceField(w, subf); err != nil {
+			return err
+		}
+		if err := g.doTemplate(w, f, `
+	{{ .Name }}[k] = v
+`); err != nil {
+			return err
+		}
+
 	case reflect.Ptr:
 		if t.Elem().Kind() != reflect.Struct {
 			return fmt.Errorf("unsupported map elem ptr type: %s", t)
@@ -1623,7 +1643,7 @@ func (t *{{ .Name}}) UnmarshalCBOR(r io.Reader) (err error) {
 	if extra < {{ .MandatoryFieldCount }} {
 		return fmt.Errorf("cbor input has too few fields %d < {{ .MandatoryFieldCount }}", extra)
 	}
-	
+
 	fieldCount := extra
 {{ end }}
 

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -37,6 +37,7 @@ func main() {
 		types.TestConstField{},
 		types.TestCanonicalFieldOrder{},
 		types.MapStringString{},
+		types.MapStringSliceString{},
 		types.TestSliceNilPreserve{},
 		types.StringPtrSlices{},
 		types.FieldNameOverlap{},

--- a/testing/cbor_map_gen.go
+++ b/testing/cbor_map_gen.go
@@ -2844,6 +2844,208 @@ func (t *MapStringString) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
+func (t *MapStringSliceString) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{161}); err != nil {
+		return err
+	}
+
+	// t.SnorkleMultiblump (map[string][]string) (map)
+	if len("SnorkleMultiblump") > 8192 {
+		return xerrors.Errorf("Value in field \"SnorkleMultiblump\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("SnorkleMultiblump"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("SnorkleMultiblump")); err != nil {
+		return err
+	}
+
+	{
+		if len(t.SnorkleMultiblump) > 4096 {
+			return xerrors.Errorf("cannot marshal t.SnorkleMultiblump map too large")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajMap, uint64(len(t.SnorkleMultiblump))); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(t.SnorkleMultiblump))
+		for k := range t.SnorkleMultiblump {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := t.SnorkleMultiblump[k]
+
+			if len(k) > 8192 {
+				return xerrors.Errorf("Value in field k was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(k))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(k)); err != nil {
+				return err
+			}
+
+			if len(v) > 8192 {
+				return xerrors.Errorf("Slice value in field v was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(v))); err != nil {
+				return err
+			}
+			for _, v := range v {
+				if len(v) > 8192 {
+					return xerrors.Errorf("Value in field v was too long")
+				}
+
+				if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+					return err
+				}
+				if _, err := cw.WriteString(string(v)); err != nil {
+					return err
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *MapStringSliceString) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = MapStringSliceString{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("MapStringSliceString: map struct too large (%d)", extra)
+	}
+
+	n := extra
+
+	nameBuf := make([]byte, 17)
+	for i := uint64(0); i < n; i++ {
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 8192)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(cr, func(cid.Cid) {}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
+		// t.SnorkleMultiblump (map[string][]string) (map)
+		case "SnorkleMultiblump":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajMap {
+				return fmt.Errorf("expected a map (major type 5)")
+			}
+			if extra > 4096 {
+				return fmt.Errorf("t.SnorkleMultiblump: map too large")
+			}
+
+			t.SnorkleMultiblump = make(map[string][]string, extra)
+
+			for i, l := 0, int(extra); i < l; i++ {
+
+				var k string
+
+				{
+					sval, err := cbg.ReadStringWithMax(cr, 8192)
+					if err != nil {
+						return err
+					}
+
+					k = string(sval)
+				}
+
+				var v []string
+
+				maj, extra, err = cr.ReadHeader()
+				if err != nil {
+					return err
+				}
+
+				if extra > 8192 {
+					return fmt.Errorf("v: array too large (%d)", extra)
+				}
+
+				if maj != cbg.MajArray {
+					return fmt.Errorf("expected cbor array")
+				}
+
+				if extra > 0 {
+					v = make([]string, extra)
+				}
+
+				for i := 0; i < int(extra); i++ {
+					{
+						var maj byte
+						var extra uint64
+						var err error
+						_ = maj
+						_ = extra
+						_ = err
+
+						{
+							sval, err := cbg.ReadStringWithMax(cr, 8192)
+							if err != nil {
+								return err
+							}
+
+							v[i] = string(sval)
+						}
+
+					}
+				}
+
+				t.SnorkleMultiblump[k] = v
+
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(r, func(cid.Cid) {}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 func (t *TestSliceNilPreserve) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -465,19 +465,8 @@ func TestConstRoundtrip(t *testing.T) {
 		Thing: 16223,
 	}
 
-	buf := new(bytes.Buffer)
-	if err := tcf.MarshalCBOR(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	fmt.Printf("%x\n", buf.Bytes())
-
 	var out TestConstField
-	if err := out.UnmarshalCBOR(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	fmt.Println(out)
+	testValueRoundtrip(t, tcf, &out)
 }
 
 func TestMapOfStringToString(t *testing.T) {
@@ -498,17 +487,8 @@ func TestMapOfStringToString(t *testing.T) {
 		"Still":       "Here with the ones that I came with",
 	}}
 
-	buf := new(bytes.Buffer)
-	if err := mss.MarshalCBOR(buf); err != nil {
-		t.Fatal(err)
-	}
-
 	var out MapStringString
-	if err := out.UnmarshalCBOR(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	fmt.Println(out)
+	testValueRoundtrip(t, mss, &out)
 }
 
 //TODO same for strings

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -491,6 +491,17 @@ func TestMapOfStringToString(t *testing.T) {
 	testValueRoundtrip(t, mss, &out)
 }
 
+func TestMapOfStringToSliceString(t *testing.T) {
+	mss := &MapStringSliceString{SnorkleMultiblump: map[string][]string{
+		"This snorkle is empty": {},
+		"This snorkle has":      {"just one blump"},
+		"This snorkle":          {"has multiple", "blumps"},
+	}}
+
+	var out MapStringSliceString
+	testValueRoundtrip(t, mss, &out)
+}
+
 //TODO same for strings
 
 func TestTransparentIntArray(t *testing.T) {

--- a/testing/types.go
+++ b/testing/types.go
@@ -147,6 +147,10 @@ type MapStringString struct {
 	Snorkleblump map[string]string
 }
 
+type MapStringSliceString struct {
+	SnorkleMultiblump map[string][]string
+}
+
 type TestSliceNilPreserve struct {
 	Cat      string
 	Stuff    []uint64


### PR DESCRIPTION
I would like to be able to marshal/unmarshal a `http.Header` which has type `map[string][]string`. This is my attempt at making it work.

I've also updated a couple of the existing test cases to compare their output against their input rather than just passing it to `fmt.Println()`.
