### PR TITLE
Revert "feat: support negative big.Ints via CBOR negative bignums"

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -477,21 +477,15 @@ func (g Gen) emitCborMarshalStructField(w io.Writer, f Field) error {
 	case bigIntType:
 		return g.doTemplate(w, f, `
 	{
-		// CBOR bignums (RFC 8949 3.4.3): tag 2 for non-negative values, tag 3
-		// for negative ones. A tag-3 byte string holds n where the value is
-		// -1 - n, so a negative x is stored as n = -1 - x = -(x + 1).
-		tag := uint64(2)
+		if {{ .Name }} != nil && {{ .Name }}.Sign() < 0 {
+			return xerrors.Errorf("Value in field {{ .Name | js }} was a negative big-integer (not supported)")
+		}
+		if err := cw.CborWriteHeader(cbg.MajTag, 2); err != nil {
+			return err
+		}
 		var b []byte
 		if {{ .Name }} != nil {
-			if {{ .Name }}.Sign() < 0 {
-				tag = 3
-				b = new(big.Int).Sub(new(big.Int).Neg({{ .Name }}), big.NewInt(1)).Bytes()
-			} else {
-				b = {{ .Name }}.Bytes()
-			}
-		}
-		if err := cw.CborWriteHeader(cbg.MajTag, tag); err != nil {
-			return err
+			b = {{ .Name }}.Bytes()
 		}
 
 		if err := cw.CborWriteHeader(cbg.MajByteString, uint64(len(b))); err != nil {
@@ -942,45 +936,36 @@ func (g Gen) emitCborUnmarshalStructField(w io.Writer, f Field) error {
 	switch f.Type {
 	case bigIntType:
 		return g.doTemplate(w, f, `
-	{
-		maj, extra, err = {{ ReadHeader "cr" }}
-		if err != nil {
+	maj, extra, err = {{ ReadHeader "cr" }}
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajTag || extra != 2 {
+		return fmt.Errorf("big ints should be cbor bignums")
+	}
+
+	maj, extra, err = {{ ReadHeader "cr" }}
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("big ints should be tagged cbor byte strings")
+	}
+
+	if extra > 256 {
+		return fmt.Errorf("{{ .Name }}: cbor bignum was too large")
+	}
+
+	if extra > 0 {
+		buf := make([]byte, extra)
+		if _, err := io.ReadFull(cr, buf); err != nil {
 			return err
 		}
-
-		// CBOR bignums (RFC 8949 3.4.3): tag 2 is non-negative, tag 3 negative.
-		if maj != cbg.MajTag || (extra != 2 && extra != 3) {
-			return fmt.Errorf("big ints should be cbor bignums")
-		}
-		negative := extra == 3
-
-		maj, extra, err = {{ ReadHeader "cr" }}
-		if err != nil {
-			return err
-		}
-
-		if maj != cbg.MajByteString {
-			return fmt.Errorf("big ints should be tagged cbor byte strings")
-		}
-
-		if extra > 256 {
-			return fmt.Errorf("{{ .Name }}: cbor bignum was too large")
-		}
-
-		if extra > 0 {
-			buf := make([]byte, extra)
-			if _, err := io.ReadFull(cr, buf); err != nil {
-				return err
-			}
-			{{ .Name }} = big.NewInt(0).SetBytes(buf)
-		} else {
-			{{ .Name }} = big.NewInt(0)
-		}
-
-		// A tag-3 byte string encodes n where the value is -1 - n.
-		if negative {
-			{{ .Name }}.Sub(big.NewInt(-1), {{ .Name }})
-		}
+		{{ .Name }} = big.NewInt(0).SetBytes(buf)
+	} else {
+		{{ .Name }} = big.NewInt(0)
 	}
 `)
 	case cidType:

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -2118,21 +2118,15 @@ func (t *BigIntContainer) MarshalCBOR(w io.Writer) error {
 
 	// t.Int (big.Int) (struct)
 	{
-		// CBOR bignums (RFC 8949 3.4.3): tag 2 for non-negative values, tag 3
-		// for negative ones. A tag-3 byte string holds n where the value is
-		// -1 - n, so a negative x is stored as n = -1 - x = -(x + 1).
-		tag := uint64(2)
+		if t.Int != nil && t.Int.Sign() < 0 {
+			return xerrors.Errorf("Value in field t.Int was a negative big-integer (not supported)")
+		}
+		if err := cw.CborWriteHeader(cbg.MajTag, 2); err != nil {
+			return err
+		}
 		var b []byte
 		if t.Int != nil {
-			if t.Int.Sign() < 0 {
-				tag = 3
-				b = new(big.Int).Sub(new(big.Int).Neg(t.Int), big.NewInt(1)).Bytes()
-			} else {
-				b = t.Int.Bytes()
-			}
-		}
-		if err := cw.CborWriteHeader(cbg.MajTag, tag); err != nil {
-			return err
+			b = t.Int.Bytes()
 		}
 
 		if err := cw.CborWriteHeader(cbg.MajByteString, uint64(len(b))); err != nil {
@@ -2170,45 +2164,36 @@ func (t *BigIntContainer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	// t.Int (big.Int) (struct)
 
-	{
-		maj, extra, err = cr.ReadHeader()
-		if err != nil {
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajTag || extra != 2 {
+		return fmt.Errorf("big ints should be cbor bignums")
+	}
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("big ints should be tagged cbor byte strings")
+	}
+
+	if extra > 256 {
+		return fmt.Errorf("t.Int: cbor bignum was too large")
+	}
+
+	if extra > 0 {
+		buf := make([]byte, extra)
+		if _, err := io.ReadFull(cr, buf); err != nil {
 			return err
 		}
-
-		// CBOR bignums (RFC 8949 3.4.3): tag 2 is non-negative, tag 3 negative.
-		if maj != cbg.MajTag || (extra != 2 && extra != 3) {
-			return fmt.Errorf("big ints should be cbor bignums")
-		}
-		negative := extra == 3
-
-		maj, extra, err = cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-
-		if maj != cbg.MajByteString {
-			return fmt.Errorf("big ints should be tagged cbor byte strings")
-		}
-
-		if extra > 256 {
-			return fmt.Errorf("t.Int: cbor bignum was too large")
-		}
-
-		if extra > 0 {
-			buf := make([]byte, extra)
-			if _, err := io.ReadFull(cr, buf); err != nil {
-				return err
-			}
-			t.Int = big.NewInt(0).SetBytes(buf)
-		} else {
-			t.Int = big.NewInt(0)
-		}
-
-		// A tag-3 byte string encodes n where the value is -1 - n.
-		if negative {
-			t.Int.Sub(big.NewInt(-1), t.Int)
-		}
+		t.Int = big.NewInt(0).SetBytes(buf)
+	} else {
+		t.Int = big.NewInt(0)
 	}
 	return nil
 }

--- a/testing/roundtrip_test.go
+++ b/testing/roundtrip_test.go
@@ -60,19 +60,10 @@ func TestLongStrings(t *testing.T) {
 }
 
 func TestBigInt(t *testing.T) {
-	bigPos, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
-	bigNeg := new(big.Int).Neg(bigPos)
-
 	for _, v := range []BigIntContainer{
 		{Int: big.NewInt(100)},
 		{Int: big.NewInt(0)},
 		{Int: nil},
-		// negative values: CBOR negative bignums (tag 3)
-		{Int: big.NewInt(-1)},
-		{Int: big.NewInt(-100)},
-		{Int: big.NewInt(-256)},
-		{Int: bigPos},
-		{Int: bigNeg},
 	} {
 
 		var buf bytes.Buffer
@@ -89,38 +80,14 @@ func TestBigInt(t *testing.T) {
 				t.Fatal("expected nil to serialize to 0")
 			}
 		} else if v.Int.Cmp(o.Int) != 0 {
-			t.Fatalf("did not round-trip: got %s want %s", o.Int, v.Int)
+			t.Fatal("did not round-trip")
 		}
 	}
-}
-
-// TestBigIntGolden pins the CBOR wire form of a few representative values so the
-// tag-2/tag-3 (positive/negative bignum) encoding can't drift unnoticed.
-func TestBigIntGolden(t *testing.T) {
-	cases := []struct {
-		val    int64
-		golden []byte // the encoded big.Int field (the array header is omitted)
-	}{
-		{0, []byte{0xc2, 0x40}},          // tag 2, empty byte string
-		{100, []byte{0xc2, 0x41, 0x64}},  // tag 2, 0x64
-		{-1, []byte{0xc3, 0x40}},         // tag 3, n=0  -> -1 - 0
-		{-256, []byte{0xc3, 0x41, 0xff}}, // tag 3, n=255 -> -1 - 255
-	}
-
-	for _, tc := range cases {
-		var buf bytes.Buffer
-		v := BigIntContainer{Int: big.NewInt(tc.val)}
-		if err := v.MarshalCBOR(&buf); err != nil {
-			t.Fatalf("marshal %d: %v", tc.val, err)
-		}
-		// Strip the single-element tuple array header (0x81).
-		enc := buf.Bytes()
-		if len(enc) == 0 || enc[0] != 0x81 {
-			t.Fatalf("%d: expected array header 0x81, got %x", tc.val, enc)
-		}
-		if got := enc[1:]; !bytes.Equal(got, tc.golden) {
-			t.Fatalf("%d: encoding mismatch: got %x want %x", tc.val, got, tc.golden)
-		}
+	var buf bytes.Buffer
+	v := BigIntContainer{Int: big.NewInt(-1)}
+	err := v.MarshalCBOR(&buf)
+	if err == nil {
+		t.Fatal("marshalling a negative int should have failed")
 	}
 }
 


### PR DESCRIPTION
This reverts commit 8fc13e31e6ca1191b2a5c8d872103a1a6955420d.

Wow Github UI w/ forks is awful. Also how there no branch protection/require maintainer review here @whyrusleeping! Sorry reverting this (but expect a more polite PR to follow :-) )