### PR TITLE
Transparent opaque wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,50 @@ type TransparentExample struct {
 }
 ```
 
+#### Opaque Wrapper Types
+
+A common Go idiom for making invalid states unrepresentable is the "opaque
+wrapper": a struct whose sole field is **unexported**, so values can only be
+produced by a validating constructor. Identifier types such as
+[`go-address.Address`](https://github.com/filecoin-project/go-address) follow
+this pattern and previously had to hand-roll their CBOR codecs.
+
+cbor-gen can generate the codec for these types when the single unexported
+field is tagged `transparent`. Because the generated code must reach the
+unexported field, **it has to be generated into the type's own package**, and
+any `parse=` constructor must live there too. Opaque wrappers must use tuple
+encoding (`WriteTupleEncodersToFile`); transparent types are not supported in
+map mode.
+
+The following options refine how the (string-kinded) field is encoded:
+
+| Option | Effect |
+| --- | --- |
+| `bytes` | encode as a CBOR byte string (`MajByteString`) instead of a text string |
+| `nullable` | encode the zero value as CBOR null, and decode CBOR null back to the zero value |
+| `parse=Fn` | on decode, call the package-level constructor `Fn(value) (T, error)` to validate the value (`Fn` receives a `string` by default, or a `[]byte` when `bytes` is also set) |
+| `maxlen=N` | reject values longer than `N` on encode and decode |
+
+For example, the equivalents of `did.DID` (a nullable, validated text string)
+and `go-address.Address` (a validated byte string) are:
+
+```go
+type DID struct {
+	str string `cborgen:"transparent,parse=Parse,nullable"`
+}
+
+func Parse(s string) (DID, error) { /* ... */ }
+
+type Address struct {
+	str string `cborgen:"transparent,bytes,parse=NewFromBytes,maxlen=64"`
+}
+
+func NewFromBytes(b []byte) (Address, error) { /* ... */ }
+```
+
+If `parse=` is omitted, the decoded value is assigned to the field directly
+without validation.
+
 ### Upgrading Type Schemas
 
 When working with map-encoded types, all fields are optional when decoding (they default to the field's zero-value) and unknown fields are skipped.

--- a/gen.go
+++ b/gen.go
@@ -152,6 +152,31 @@ type Field struct {
 	IterLabel   string
 
 	MaxLen int
+
+	// The following options are only meaningful for a transparent scalar
+	// (string-kinded) field, i.e. an "opaque wrapper" type such as a
+	// validating identifier whose sole field is unexported.
+	Bytes     bool   // encode the string as a CBOR byte string instead of a text string
+	Nullable  bool   // encode the zero value as CBOR null (and decode null back to it)
+	ParseFunc string // package-level constructor "func(T) (Self, error)" to validate on decode
+}
+
+// ScalarMajorType returns the CBOR major type used to encode a string-kinded
+// field: a byte string when Bytes is set, a text string otherwise.
+func (f Field) ScalarMajorType() string {
+	if f.Bytes {
+		return "cbg.MajByteString"
+	}
+	return "cbg.MajTextString"
+}
+
+// ScalarMaxLenType selects which configured maximum length applies to a
+// string-kinded field ("Bytes" or "String"); see the MaxLen template helper.
+func (f Field) ScalarMaxLenType() string {
+	if f.Bytes {
+		return "Bytes"
+	}
+	return "String"
 }
 
 func typeName(pkg string, t reflect.Type) string {
@@ -281,7 +306,21 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 		}
 
 		f := t.Field(i)
-		if !nameIsExported(f.Name) {
+
+		tagval := f.Tag.Get("cborgen")
+		tags, err := tagparse(tagval)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tag format: %w", err)
+		}
+
+		_, transparent := tags["transparent"]
+
+		// Unexported fields are normally invisible to the generator. They are
+		// only included when explicitly tagged transparent, which enables
+		// "opaque wrapper" types: a struct whose sole (unexported) field holds
+		// a validated value and which encodes as that field alone. The
+		// generated code must therefore live in the type's own package.
+		if !nameIsExported(f.Name) && !transparent {
 			continue
 		}
 
@@ -294,11 +333,6 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 
 		mapk := f.Name
 		usrMaxLen := NoUsrMaxLen
-		tagval := f.Tag.Get("cborgen")
-		tags, err := tagparse(tagval)
-		if err != nil {
-			return nil, fmt.Errorf("invalid tag format: %w", err)
-		}
 
 		if _, ok := tags["ignore"]; ok {
 			continue
@@ -324,7 +358,6 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 			constval = &cv
 		}
 
-		_, transparent := tags["transparent"]
 		if transparent && len(out.Fields) > 0 {
 			return nil, fmt.Errorf("only one transparent field is allowed")
 		}
@@ -338,6 +371,22 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 			return nil, fmt.Errorf("%T.%s: preservenil is only supported on slice types", itype, f.Name)
 		}
 
+		_, asBytes := tags["bytes"]
+		_, nullable := tags["nullable"]
+		parseFunc := tags["parse"]
+
+		// bytes/nullable/parse only make sense for an opaque scalar wrapper: a
+		// transparent, string-kinded field. Reject the combinations early so
+		// misuse fails at generation time rather than producing broken code.
+		if asBytes || nullable || parseFunc != "" {
+			if !transparent {
+				return nil, fmt.Errorf("%T.%s: bytes, nullable and parse options require the transparent tag", itype, f.Name)
+			}
+			if ft.Kind() != reflect.String {
+				return nil, fmt.Errorf("%T.%s: bytes, nullable and parse options are only supported on string-kinded fields", itype, f.Name)
+			}
+		}
+
 		out.Fields = append(out.Fields, Field{
 			Name:        f.Name,
 			MapKey:      mapk,
@@ -349,6 +398,9 @@ func ParseTypeInfo(itype interface{}) (*GenTypeInfo, error) {
 			MaxLen:      usrMaxLen,
 			Const:       constval,
 			Optional:    optional,
+			Bytes:       asBytes,
+			Nullable:    nullable,
+			ParseFunc:   parseFunc,
 		})
 	}
 
@@ -388,6 +440,10 @@ func tagparse(v string) (map[string]string, error) {
 			out["ignore"] = "true"
 		} else if elem == "transparent" {
 			out["transparent"] = "true"
+		} else if elem == "bytes" {
+			out["bytes"] = "true"
+		} else if elem == "nullable" {
+			out["nullable"] = "true"
 		} else if elem == "optional" {
 			out["optional"] = "true"
 		} else {
@@ -460,7 +516,10 @@ func (g Gen) emitCborMarshalStringField(w io.Writer, f Field) error {
 
 	}
 
-	return g.doTemplate(w, f, `
+	// Plain string fields keep their original encoding. The richer template
+	// below is only needed for opaque-wrapper fields (bytes/nullable/parse).
+	if !f.Bytes && !f.Nullable && f.ParseFunc == "" {
+		return g.doTemplate(w, f, `
 	if len({{ .Name }}) > {{ MaxLen .MaxLen "String" }} {
 		return xerrors.Errorf("Value in field {{ .Name | js }} was too long")
 	}
@@ -469,6 +528,28 @@ func (g Gen) emitCborMarshalStringField(w io.Writer, f Field) error {
 	if _, err := cw.WriteString(string({{ .Name }})); err != nil {
 		return err
 	}
+`)
+	}
+
+	return g.doTemplate(w, f, `
+{{ if .Nullable }}
+	if {{ .Name }} == "" {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+{{ end }}
+	if len({{ .Name }}) > {{ MaxLen .MaxLen .ScalarMaxLenType }} {
+		return xerrors.Errorf("Value in field {{ .Name | js }} was too long")
+	}
+
+	{{ MajorType "cw" .ScalarMajorType (print "len(" .Name ")") }}
+	if _, err := cw.WriteString(string({{ .Name }})); err != nil {
+		return err
+	}
+{{ if .Nullable }}
+	}
+{{ end }}
 `)
 }
 
@@ -920,7 +1001,11 @@ func (g Gen) emitCborUnmarshalStringField(w io.Writer, f Field) error {
 	if f.Type == nil {
 		f.Type = reflect.TypeOf("")
 	}
-	return g.doTemplate(w, f, `
+
+	// Plain string fields keep their original decoding. The richer template
+	// below is only needed for opaque-wrapper fields (bytes/nullable/parse).
+	if !f.Bytes && !f.Nullable && f.ParseFunc == "" {
+		return g.doTemplate(w, f, `
 	{
 		sval, err := cbg.ReadStringWithMax(cr, {{  MaxLen 0 "String" }})
 		if err != nil {
@@ -928,6 +1013,54 @@ func (g Gen) emitCborUnmarshalStringField(w io.Writer, f Field) error {
 		}
 
 		{{ .Name }} = {{ .TypeName }}(sval)
+	}
+`)
+	}
+
+	return g.doTemplate(w, f, `
+	{
+{{ if .Nullable }}
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+{{ end }}
+{{ if .Bytes }}
+		bval, err := cbg.ReadByteArray(cr, {{ MaxLen .MaxLen .ScalarMaxLenType }})
+		if err != nil {
+			return err
+		}
+{{ if .ParseFunc }}
+		parsed, err := {{ .ParseFunc }}(bval)
+		if err != nil {
+			return err
+		}
+		*t = parsed
+{{ else }}
+		{{ .Name }} = {{ .TypeName }}(bval)
+{{ end }}
+{{ else }}
+		sval, err := cbg.ReadStringWithMax(cr, {{ MaxLen .MaxLen .ScalarMaxLenType }})
+		if err != nil {
+			return err
+		}
+{{ if .ParseFunc }}
+		parsed, err := {{ .ParseFunc }}(sval)
+		if err != nil {
+			return err
+		}
+		*t = parsed
+{{ else }}
+		{{ .Name }} = {{ .TypeName }}(sval)
+{{ end }}
+{{ end }}
+{{ if .Nullable }}
+		}
+{{ end }}
 	}
 `)
 }

--- a/gen_test.go
+++ b/gen_test.go
@@ -1,0 +1,75 @@
+package typegen
+
+import "testing"
+
+// TestParseTypeInfoOpaqueWrapper covers the "opaque wrapper" support: a struct
+// whose sole unexported field is tagged transparent, optionally with the
+// bytes/nullable/parse options.
+func TestParseTypeInfoOpaqueWrapper(t *testing.T) {
+	type wrapper struct {
+		str string `cborgen:"transparent,bytes,nullable,parse=Parse,maxlen=64"`
+	}
+
+	gti, err := ParseTypeInfo(wrapper{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gti.Transparent {
+		t.Fatal("expected type to be transparent")
+	}
+	if len(gti.Fields) != 1 {
+		t.Fatalf("expected exactly one field, got %d", len(gti.Fields))
+	}
+
+	f := gti.Fields[0]
+	if f.Name != "str" {
+		t.Fatalf("expected unexported field 'str' to be included, got %q", f.Name)
+	}
+	if !f.Bytes || !f.Nullable {
+		t.Fatalf("expected Bytes and Nullable to be set, got Bytes=%v Nullable=%v", f.Bytes, f.Nullable)
+	}
+	if f.ParseFunc != "Parse" {
+		t.Fatalf("expected ParseFunc 'Parse', got %q", f.ParseFunc)
+	}
+	if f.MaxLen != 64 {
+		t.Fatalf("expected MaxLen 64, got %d", f.MaxLen)
+	}
+}
+
+// TestParseTypeInfoUntaggedUnexportedSkipped confirms an unexported field with
+// no transparent tag is still ignored (existing behavior preserved).
+func TestParseTypeInfoUntaggedUnexportedSkipped(t *testing.T) {
+	type hidden struct {
+		secret string
+	}
+
+	gti, err := ParseTypeInfo(hidden{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gti.Fields) != 0 {
+		t.Fatalf("expected unexported untagged field to be skipped, got %d fields", len(gti.Fields))
+	}
+}
+
+// TestParseTypeInfoOpaqueOptionMisuse confirms the new options are rejected
+// outside of their supported context.
+func TestParseTypeInfoOpaqueOptionMisuse(t *testing.T) {
+	t.Run("bytes without transparent", func(t *testing.T) {
+		type bad struct {
+			S string `cborgen:"bytes"`
+		}
+		if _, err := ParseTypeInfo(bad{}); err == nil {
+			t.Fatal("expected error for bytes option without transparent")
+		}
+	})
+
+	t.Run("parse on non-string", func(t *testing.T) {
+		type bad struct {
+			N uint64 `cborgen:"transparent,parse=Parse"`
+		}
+		if _, err := ParseTypeInfo(bad{}); err == nil {
+			t.Fatal("expected error for parse option on non-string field")
+		}
+	})
+}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -23,6 +23,9 @@ func main() {
 		types.MapTransparentType{},
 		types.BigIntContainer{},
 		types.TupleWithOptionalFields{},
+		types.OpaqueString{},
+		types.OpaqueBytes{},
+		types.OpaqueDirect{},
 	); err != nil {
 		panic(err)
 	}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -30,6 +30,7 @@ func main() {
 		types.OpaqueNullableDirect{},
 		types.OpaqueBytesNullable{},
 		types.OpaqueContainer{},
+		types.DID{},
 	); err != nil {
 		panic(err)
 	}

--- a/testgen/main.go
+++ b/testgen/main.go
@@ -26,6 +26,10 @@ func main() {
 		types.OpaqueString{},
 		types.OpaqueBytes{},
 		types.OpaqueDirect{},
+		types.OpaqueBytesDirect{},
+		types.OpaqueNullableDirect{},
+		types.OpaqueBytesNullable{},
+		types.OpaqueContainer{},
 	); err != nil {
 		panic(err)
 	}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -2380,3 +2380,152 @@ func (t *TupleWithOptionalFields) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+func (t *OpaqueString) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.str (string) (string)
+
+	if t.str == "" {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+
+		if len(t.str) > 8192 {
+			return xerrors.Errorf("Value in field t.str was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.str))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string(t.str)); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (t *OpaqueString) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueString{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.str (string) (string)
+
+	{
+
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+
+			sval, err := cbg.ReadStringWithMax(cr, 8192)
+			if err != nil {
+				return err
+			}
+
+			parsed, err := ParseOpaqueString(sval)
+			if err != nil {
+				return err
+			}
+			*t = parsed
+
+		}
+
+	}
+	return nil
+}
+
+func (t *OpaqueBytes) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.raw (string) (string)
+
+	if len(t.raw) > 8 {
+		return xerrors.Errorf("Value in field t.raw was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.raw))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.raw)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *OpaqueBytes) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueBytes{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.raw (string) (string)
+
+	{
+
+		bval, err := cbg.ReadByteArray(cr, 8)
+		if err != nil {
+			return err
+		}
+
+		parsed, err := NewOpaqueBytes(bval)
+		if err != nil {
+			return err
+		}
+		*t = parsed
+
+	}
+	return nil
+}
+
+func (t *OpaqueDirect) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.val (string) (string)
+	if len(t.val) > 8192 {
+		return xerrors.Errorf("Value in field t.val was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.val))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.val)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *OpaqueDirect) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueDirect{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.val (string) (string)
+
+	{
+		sval, err := cbg.ReadStringWithMax(cr, 8192)
+		if err != nil {
+			return err
+		}
+
+		t.val = string(sval)
+	}
+	return nil
+}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -2763,3 +2763,68 @@ func (t *OpaqueContainer) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+func (t *DID) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.str (string) (string)
+
+	if t.str == "" {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+
+		if len(t.str) > 8192 {
+			return xerrors.Errorf("Value in field t.str was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.str))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string(t.str)); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (t *DID) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = DID{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.str (string) (string)
+
+	{
+
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+
+			sval, err := cbg.ReadStringWithMax(cr, 8192)
+			if err != nil {
+				return err
+			}
+
+			parsed, err := ParseDID(sval)
+			if err != nil {
+				return err
+			}
+			*t = parsed
+
+		}
+
+	}
+	return nil
+}

--- a/testing/cbor_gen.go
+++ b/testing/cbor_gen.go
@@ -2529,3 +2529,237 @@ func (t *OpaqueDirect) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+func (t *OpaqueBytesDirect) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.raw (string) (string)
+
+	if len(t.raw) > 2097152 {
+		return xerrors.Errorf("Value in field t.raw was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.raw))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.raw)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *OpaqueBytesDirect) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueBytesDirect{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.raw (string) (string)
+
+	{
+
+		bval, err := cbg.ReadByteArray(cr, 2097152)
+		if err != nil {
+			return err
+		}
+
+		t.raw = string(bval)
+
+	}
+	return nil
+}
+
+func (t *OpaqueNullableDirect) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.val (string) (string)
+
+	if t.val == "" {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+
+		if len(t.val) > 8192 {
+			return xerrors.Errorf("Value in field t.val was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.val))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string(t.val)); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (t *OpaqueNullableDirect) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueNullableDirect{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.val (string) (string)
+
+	{
+
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+
+			sval, err := cbg.ReadStringWithMax(cr, 8192)
+			if err != nil {
+				return err
+			}
+
+			t.val = string(sval)
+
+		}
+
+	}
+	return nil
+}
+
+func (t *OpaqueBytesNullable) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.raw (string) (string)
+
+	if t.raw == "" {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+
+		if len(t.raw) > 2097152 {
+			return xerrors.Errorf("Value in field t.raw was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.raw))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string(t.raw)); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func (t *OpaqueBytesNullable) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueBytesNullable{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.raw (string) (string)
+
+	{
+
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+
+			bval, err := cbg.ReadByteArray(cr, 2097152)
+			if err != nil {
+				return err
+			}
+
+			t.raw = string(bval)
+
+		}
+
+	}
+	return nil
+}
+
+var lengthBufOpaqueContainer = []byte{130}
+
+func (t *OpaqueContainer) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufOpaqueContainer); err != nil {
+		return err
+	}
+
+	// t.Name (testing.OpaqueString) (struct)
+	if err := t.Name.MarshalCBOR(cw); err != nil {
+		return err
+	}
+
+	// t.Data (testing.OpaqueBytes) (struct)
+	if err := t.Data.MarshalCBOR(cw); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *OpaqueContainer) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = OpaqueContainer{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Name (testing.OpaqueString) (struct)
+
+	{
+
+		if err := t.Name.UnmarshalCBOR(cr); err != nil {
+			return xerrors.Errorf("unmarshaling t.Name: %w", err)
+		}
+
+	}
+	// t.Data (testing.OpaqueBytes) (struct)
+
+	{
+
+		if err := t.Data.UnmarshalCBOR(cr); err != nil {
+			return xerrors.Errorf("unmarshaling t.Data: %w", err)
+		}
+
+	}
+	return nil
+}

--- a/testing/opaque.go
+++ b/testing/opaque.go
@@ -1,0 +1,59 @@
+package testing
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The types in this file exercise the "opaque wrapper" pattern: a struct whose
+// sole, unexported field holds a validated value and which encodes
+// transparently as that field alone. This mirrors real-world types such as
+// filecoin-project/go-address.Address, and ucantone's did.DID and
+// command.Command, which previously had to hand-roll their CBOR codecs.
+
+// OpaqueString is encoded as a transparent CBOR text string. It carries a
+// validating constructor (parse=) and treats its zero value as CBOR null
+// (nullable), mirroring did.DID / command.Command.
+type OpaqueString struct {
+	str string `cborgen:"transparent,parse=ParseOpaqueString,nullable"`
+}
+
+// ParseOpaqueString validates s and returns an OpaqueString. The empty string
+// is permitted and represents the undefined value (encoded as CBOR null).
+func ParseOpaqueString(s string) (OpaqueString, error) {
+	if strings.ContainsRune(s, ' ') {
+		return OpaqueString{}, fmt.Errorf("opaque string must not contain spaces: %q", s)
+	}
+	return OpaqueString{str: s}, nil
+}
+
+func (o OpaqueString) String() string { return o.str }
+
+// OpaqueBytes is encoded as a transparent CBOR byte string with a validating
+// constructor, mirroring go-address.Address. Its zero value is not nullable;
+// an empty payload is rejected on decode by the constructor.
+type OpaqueBytes struct {
+	raw string `cborgen:"transparent,bytes,parse=NewOpaqueBytes,maxlen=8"`
+}
+
+// NewOpaqueBytes validates b and returns an OpaqueBytes. An empty payload is
+// rejected.
+func NewOpaqueBytes(b []byte) (OpaqueBytes, error) {
+	if len(b) == 0 {
+		return OpaqueBytes{}, fmt.Errorf("opaque bytes must not be empty")
+	}
+	return OpaqueBytes{raw: string(b)}, nil
+}
+
+func (o OpaqueBytes) Bytes() []byte { return []byte(o.raw) }
+
+// OpaqueDirect is a transparent wrapper around an unexported string with no
+// validating constructor; decoding assigns the field directly. It verifies
+// that the unexported-field path works without a parse= hook.
+type OpaqueDirect struct {
+	val string `cborgen:"transparent"`
+}
+
+func NewOpaqueDirect(s string) OpaqueDirect { return OpaqueDirect{val: s} }
+
+func (o OpaqueDirect) String() string { return o.val }

--- a/testing/opaque.go
+++ b/testing/opaque.go
@@ -57,3 +57,43 @@ type OpaqueDirect struct {
 func NewOpaqueDirect(s string) OpaqueDirect { return OpaqueDirect{val: s} }
 
 func (o OpaqueDirect) String() string { return o.val }
+
+// OpaqueBytesDirect is a transparent wrapper encoded as a CBOR byte string with
+// no validating constructor; decoding assigns the bytes directly. It exercises
+// the `bytes` codegen path without a parse= hook.
+type OpaqueBytesDirect struct {
+	raw string `cborgen:"transparent,bytes"`
+}
+
+func NewOpaqueBytesDirect(b []byte) OpaqueBytesDirect { return OpaqueBytesDirect{raw: string(b)} }
+
+func (o OpaqueBytesDirect) Bytes() []byte { return []byte(o.raw) }
+
+// OpaqueNullableDirect is a transparent text-string wrapper whose zero value is
+// nullable and which has no validating constructor. It exercises the nullable
+// codegen path with direct field assignment (no parse= hook).
+type OpaqueNullableDirect struct {
+	val string `cborgen:"transparent,nullable"`
+}
+
+func NewOpaqueNullableDirect(s string) OpaqueNullableDirect { return OpaqueNullableDirect{val: s} }
+
+func (o OpaqueNullableDirect) String() string { return o.val }
+
+// OpaqueBytesNullable combines the `bytes` and `nullable` options on a single
+// transparent field with no constructor: the zero value encodes as CBOR null,
+// any other value as a byte string assigned directly on decode.
+type OpaqueBytesNullable struct {
+	raw string `cborgen:"transparent,bytes,nullable"`
+}
+
+func NewOpaqueBytesNullable(b []byte) OpaqueBytesNullable { return OpaqueBytesNullable{raw: string(b)} }
+
+func (o OpaqueBytesNullable) Bytes() []byte { return []byte(o.raw) }
+
+// OpaqueContainer holds opaque wrappers as exported fields, verifying that the
+// generated types compose as fields of another generated (tuple) type.
+type OpaqueContainer struct {
+	Name OpaqueString
+	Data OpaqueBytes
+}

--- a/testing/opaque.go
+++ b/testing/opaque.go
@@ -91,6 +91,35 @@ func NewOpaqueBytesNullable(b []byte) OpaqueBytesNullable { return OpaqueBytesNu
 
 func (o OpaqueBytesNullable) Bytes() []byte { return []byte(o.raw) }
 
+// DID is a worked example of the opaque-wrapper pattern applied to a real type:
+// a Decentralized Identifier of the form "did:<method>:<id>". It is a faithful
+// stand-in for ucantone's did.DID — a validating constructor (ParseDID) is the
+// only way to build a non-zero value, the wire form is the bare identifier
+// string, and the zero (undefined) DID encodes as CBOR null. The generator
+// produces its CBOR codec from the field tag alone; no hand-rolled
+// MarshalCBOR/UnmarshalCBOR is required.
+type DID struct {
+	str string `cborgen:"transparent,parse=ParseDID,nullable"`
+}
+
+// ParseDID validates s and returns a DID. It accepts identifiers of the form
+// "did:<method>:<id>" with non-empty method and id segments. The empty string
+// is rejected here; the undefined DID is represented by the zero value and is
+// produced only by decoding CBOR null.
+func ParseDID(s string) (DID, error) {
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 || parts[0] != "did" || parts[1] == "" || parts[2] == "" {
+		return DID{}, fmt.Errorf("invalid DID %q: expected \"did:<method>:<id>\"", s)
+	}
+	return DID{str: s}, nil
+}
+
+// Defined reports whether the DID holds a value (as opposed to the zero,
+// undefined DID that encodes as CBOR null).
+func (d DID) Defined() bool { return d.str != "" }
+
+func (d DID) String() string { return d.str }
+
 // OpaqueContainer holds opaque wrappers as exported fields, verifying that the
 // generated types compose as fields of another generated (tuple) type.
 type OpaqueContainer struct {

--- a/testing/opaque_test.go
+++ b/testing/opaque_test.go
@@ -16,6 +16,14 @@ var (
 	_ cbg.CBORUnmarshaler = (*OpaqueBytes)(nil)
 	_ cbg.CBORMarshaler   = (*OpaqueDirect)(nil)
 	_ cbg.CBORUnmarshaler = (*OpaqueDirect)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueBytesDirect)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueBytesDirect)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueNullableDirect)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueNullableDirect)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueBytesNullable)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueBytesNullable)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueContainer)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueContainer)(nil)
 )
 
 func mustMarshal(t *testing.T, m cbg.CBORMarshaler) []byte {
@@ -134,5 +142,152 @@ func TestOpaqueDirectRoundtrip(t *testing.T) {
 	}
 	if out.String() != in.String() {
 		t.Fatalf("roundtrip mismatch: got %q want %q", out.String(), in.String())
+	}
+}
+
+// TestOpaqueBytesDirectRoundtrip exercises the `bytes` codegen path without a
+// parse= hook: the byte string is assigned to the field directly on decode.
+func TestOpaqueBytesDirectRoundtrip(t *testing.T) {
+	in := NewOpaqueBytesDirect([]byte{0x0a, 0x0b})
+
+	enc := mustMarshal(t, &in)
+	want := []byte{0x42, 0x0a, 0x0b} // CBOR byte string of length 2
+	if !bytes.Equal(enc, want) {
+		t.Fatalf("encoding mismatch: got %x want %x", enc, want)
+	}
+
+	var out OpaqueBytesDirect
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), in.Bytes()) {
+		t.Fatalf("roundtrip mismatch: got %x want %x", out.Bytes(), in.Bytes())
+	}
+}
+
+// TestOpaqueNullableDirectRoundtrip exercises the nullable text-string path with
+// direct field assignment (no parse= hook): a non-empty value encodes as a text
+// string, the zero value as CBOR null.
+func TestOpaqueNullableDirectRoundtrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		val    string
+		golden []byte
+	}{
+		{"value", "foo", []byte{0x63, 'f', 'o', 'o'}},
+		{"empty", "", []byte{0xf6}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := NewOpaqueNullableDirect(tc.val)
+
+			enc := mustMarshal(t, &in)
+			if !bytes.Equal(enc, tc.golden) {
+				t.Fatalf("encoding mismatch: got %x want %x", enc, tc.golden)
+			}
+
+			var out OpaqueNullableDirect
+			if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if out.String() != tc.val {
+				t.Fatalf("roundtrip mismatch: got %q want %q", out.String(), tc.val)
+			}
+		})
+	}
+}
+
+// TestOpaqueBytesNullableRoundtrip exercises the combined bytes+nullable path: a
+// non-empty value encodes as a byte string, the zero value as CBOR null.
+func TestOpaqueBytesNullableRoundtrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		val    []byte
+		golden []byte
+	}{
+		{"value", []byte{0x01, 0x02}, []byte{0x42, 0x01, 0x02}},
+		{"empty", nil, []byte{0xf6}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := NewOpaqueBytesNullable(tc.val)
+
+			enc := mustMarshal(t, &in)
+			if !bytes.Equal(enc, tc.golden) {
+				t.Fatalf("encoding mismatch: got %x want %x", enc, tc.golden)
+			}
+
+			var out OpaqueBytesNullable
+			if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if !bytes.Equal(out.Bytes(), in.Bytes()) {
+				t.Fatalf("roundtrip mismatch: got %x want %x", out.Bytes(), in.Bytes())
+			}
+		})
+	}
+}
+
+// TestOpaqueRejectsNullWhenNotNullable confirms a CBOR null is rejected when
+// decoded into a non-nullable opaque field, rather than silently zeroing it.
+func TestOpaqueRejectsNullWhenNotNullable(t *testing.T) {
+	null := []byte{0xf6}
+
+	t.Run("bytes", func(t *testing.T) {
+		var out OpaqueBytes
+		if err := out.UnmarshalCBOR(bytes.NewReader(null)); err == nil {
+			t.Fatal("expected decode of null into non-nullable bytes field to fail")
+		}
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		var out OpaqueDirect
+		if err := out.UnmarshalCBOR(bytes.NewReader(null)); err == nil {
+			t.Fatal("expected decode of null into non-nullable string field to fail")
+		}
+	})
+}
+
+// TestOpaqueBytesMarshalRejectsOverlong confirms the maxlen=8 bound is enforced
+// on the encode path, not only on decode. The constructor permits the payload
+// (it only rejects empty), so the bound must be caught by MarshalCBOR.
+func TestOpaqueBytesMarshalRejectsOverlong(t *testing.T) {
+	in, err := NewOpaqueBytes(bytes.Repeat([]byte{0xaa}, 9))
+	if err != nil {
+		t.Fatalf("NewOpaqueBytes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := in.MarshalCBOR(&buf); err == nil {
+		t.Fatal("expected marshal of overlong payload to fail, got nil error")
+	}
+}
+
+// TestOpaqueContainerRoundtrip confirms opaque wrappers compose as fields of
+// another generated type and round-trip through it.
+func TestOpaqueContainerRoundtrip(t *testing.T) {
+	name, err := ParseOpaqueString("hello")
+	if err != nil {
+		t.Fatalf("ParseOpaqueString: %v", err)
+	}
+	data, err := NewOpaqueBytes([]byte{0x01, 0x02, 0x03})
+	if err != nil {
+		t.Fatalf("NewOpaqueBytes: %v", err)
+	}
+	in := OpaqueContainer{Name: name, Data: data}
+
+	enc := mustMarshal(t, &in)
+
+	var out OpaqueContainer
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if out.Name.String() != in.Name.String() {
+		t.Fatalf("Name mismatch: got %q want %q", out.Name.String(), in.Name.String())
+	}
+	if !bytes.Equal(out.Data.Bytes(), in.Data.Bytes()) {
+		t.Fatalf("Data mismatch: got %x want %x", out.Data.Bytes(), in.Data.Bytes())
 	}
 }

--- a/testing/opaque_test.go
+++ b/testing/opaque_test.go
@@ -24,6 +24,8 @@ var (
 	_ cbg.CBORUnmarshaler = (*OpaqueBytesNullable)(nil)
 	_ cbg.CBORMarshaler   = (*OpaqueContainer)(nil)
 	_ cbg.CBORUnmarshaler = (*OpaqueContainer)(nil)
+	_ cbg.CBORMarshaler   = (*DID)(nil)
+	_ cbg.CBORUnmarshaler = (*DID)(nil)
 )
 
 func mustMarshal(t *testing.T, m cbg.CBORMarshaler) []byte {
@@ -289,5 +291,91 @@ func TestOpaqueContainerRoundtrip(t *testing.T) {
 	}
 	if !bytes.Equal(out.Data.Bytes(), in.Data.Bytes()) {
 		t.Fatalf("Data mismatch: got %x want %x", out.Data.Bytes(), in.Data.Bytes())
+	}
+}
+
+// TestDIDRoundtrip is an end-to-end demonstration of the opaque-wrapper pattern
+// on a realistic type: a DID is built only through its validating constructor,
+// the generator-produced codec encodes it as the bare identifier string, and it
+// round-trips back to an equal value. The undefined (zero) DID encodes as CBOR
+// null and decodes back to undefined.
+func TestDIDRoundtrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		did    string
+		golden []byte
+	}{
+		{
+			name: "did:key",
+			did:  "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+			golden: append(
+				[]byte{0x78, 0x38}, // CBOR text string, length 56 (0x38) with a 1-byte length prefix
+				[]byte("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")...,
+			),
+		},
+		{
+			name:   "did:web",
+			did:    "did:web:example.com",
+			golden: append([]byte{0x73}, []byte("did:web:example.com")...), // text string, length 19 (0x13)
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := ParseDID(tc.did)
+			if err != nil {
+				t.Fatalf("ParseDID(%q): %v", tc.did, err)
+			}
+
+			enc := mustMarshal(t, &in)
+			if !bytes.Equal(enc, tc.golden) {
+				t.Fatalf("encoding mismatch: got %x want %x", enc, tc.golden)
+			}
+
+			var out DID
+			if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if !out.Defined() {
+				t.Fatal("decoded DID should be defined")
+			}
+			if out.String() != in.String() {
+				t.Fatalf("roundtrip mismatch: got %q want %q", out.String(), in.String())
+			}
+		})
+	}
+}
+
+// TestDIDUndefinedRoundtrip confirms the zero DID encodes as CBOR null and
+// decodes back to the undefined value.
+func TestDIDUndefinedRoundtrip(t *testing.T) {
+	var in DID
+	if in.Defined() {
+		t.Fatal("zero DID should be undefined")
+	}
+
+	enc := mustMarshal(t, &in)
+	if !bytes.Equal(enc, []byte{0xf6}) { // CBOR null
+		t.Fatalf("encoding mismatch: got %x want f6", enc)
+	}
+
+	var out DID
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if out.Defined() {
+		t.Fatalf("decoded DID should be undefined, got %q", out.String())
+	}
+}
+
+// TestDIDValidatesOnDecode confirms ParseDID runs on the decode path: a valid
+// CBOR text string that is not a well-formed DID is rejected.
+func TestDIDValidatesOnDecode(t *testing.T) {
+	// "not-a-did" — valid CBOR text string, but not a "did:<method>:<id>".
+	enc := append([]byte{0x69}, []byte("not-a-did")...) // text string, length 9
+
+	var out DID
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err == nil {
+		t.Fatal("expected decode of malformed DID to fail validation, got nil error")
 	}
 }

--- a/testing/opaque_test.go
+++ b/testing/opaque_test.go
@@ -1,0 +1,138 @@
+package testing
+
+import (
+	"bytes"
+	"testing"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+// Compile-time proof that the opaque wrapper types implement the CBOR
+// interfaces and therefore compose as fields of other generated types.
+var (
+	_ cbg.CBORMarshaler   = (*OpaqueString)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueString)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueBytes)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueBytes)(nil)
+	_ cbg.CBORMarshaler   = (*OpaqueDirect)(nil)
+	_ cbg.CBORUnmarshaler = (*OpaqueDirect)(nil)
+)
+
+func mustMarshal(t *testing.T, m cbg.CBORMarshaler) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := m.MarshalCBOR(&buf); err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestOpaqueStringRoundtrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		val    string
+		golden []byte
+	}{
+		// non-empty value encodes as a CBOR text string
+		{"value", "foo", []byte{0x63, 'f', 'o', 'o'}},
+		// the zero value encodes as CBOR null (nullable)
+		{"empty", "", []byte{0xf6}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := ParseOpaqueString(tc.val)
+			if err != nil {
+				t.Fatalf("ParseOpaqueString(%q): %v", tc.val, err)
+			}
+
+			enc := mustMarshal(t, &in)
+			if !bytes.Equal(enc, tc.golden) {
+				t.Fatalf("encoding mismatch: got %x want %x", enc, tc.golden)
+			}
+
+			var out OpaqueString
+			if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if out.String() != tc.val {
+				t.Fatalf("roundtrip mismatch: got %q want %q", out.String(), tc.val)
+			}
+		})
+	}
+}
+
+// TestOpaqueStringValidatesOnDecode confirms the parse= hook rejects invalid
+// input on the decode path: a text string carrying a disallowed space.
+func TestOpaqueStringValidatesOnDecode(t *testing.T) {
+	// CBOR text string "a b" — valid CBOR, but rejected by ParseOpaqueString.
+	enc := []byte{0x63, 'a', ' ', 'b'}
+
+	var out OpaqueString
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err == nil {
+		t.Fatal("expected decode to fail validation, got nil error")
+	}
+}
+
+func TestOpaqueBytesRoundtrip(t *testing.T) {
+	in, err := NewOpaqueBytes([]byte{0x01, 0x02, 0x03})
+	if err != nil {
+		t.Fatalf("NewOpaqueBytes: %v", err)
+	}
+
+	enc := mustMarshal(t, &in)
+	// CBOR byte string of length 3.
+	want := []byte{0x43, 0x01, 0x02, 0x03}
+	if !bytes.Equal(enc, want) {
+		t.Fatalf("encoding mismatch: got %x want %x", enc, want)
+	}
+
+	var out OpaqueBytes
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), in.Bytes()) {
+		t.Fatalf("roundtrip mismatch: got %x want %x", out.Bytes(), in.Bytes())
+	}
+}
+
+// TestOpaqueBytesValidatesOnDecode confirms the constructor rejects an empty
+// payload on decode.
+func TestOpaqueBytesValidatesOnDecode(t *testing.T) {
+	enc := []byte{0x40} // empty CBOR byte string
+
+	var out OpaqueBytes
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err == nil {
+		t.Fatal("expected decode of empty payload to fail, got nil error")
+	}
+}
+
+// TestOpaqueBytesRejectsOverlong confirms the maxlen=8 bound is enforced on
+// decode.
+func TestOpaqueBytesRejectsOverlong(t *testing.T) {
+	// CBOR byte string of length 9 (0x40 | 9 = 0x49) followed by 9 bytes.
+	enc := append([]byte{0x49}, bytes.Repeat([]byte{0xaa}, 9)...)
+
+	var out OpaqueBytes
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err == nil {
+		t.Fatal("expected decode of overlong payload to fail, got nil error")
+	}
+}
+
+func TestOpaqueDirectRoundtrip(t *testing.T) {
+	in := NewOpaqueDirect("bar")
+
+	enc := mustMarshal(t, &in)
+	want := []byte{0x63, 'b', 'a', 'r'}
+	if !bytes.Equal(enc, want) {
+		t.Fatalf("encoding mismatch: got %x want %x", enc, want)
+	}
+
+	var out OpaqueDirect
+	if err := out.UnmarshalCBOR(bytes.NewReader(enc)); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if out.String() != in.String() {
+		t.Fatalf("roundtrip mismatch: got %q want %q", out.String(), in.String())
+	}
+}


### PR DESCRIPTION
Support a common Go idiom — the "opaque wrapper", a struct whose sole unexported field holds a value produced only by a validating constructor. These types previously had to hand-roll MarshalCBOR/UnmarshalCBOR. (filecoins go-address implemention as an example rolls its own. Cid's got special treatment here, naturally.)

A single unexported field tagged `transparent` is now included by the generator (it was previously skipped outright). Three new tag options refine how the string-kinded field is encoded:

  - `bytes`     encode as a CBOR byte string instead of a text string
  - `nullable`  encode the zero value as CBOR null and decode it back
  - `parse=Fn`  call package-level Fn(value) (T, error) to validate on decode

The new options are rejected unless applied to a transparent, string-kinded field. Plain string fields keep their original codegen byte-for-byte. Generated code must live in the type's own package (to reach the unexported field) and opaque wrappers require tuple encoding.

Adds OpaqueString/OpaqueBytes/OpaqueDirect test types with roundtrip, validation-on-decode, maxlen and golden-byte tests, generator-level ParseTypeInfo tests, and README documentation.